### PR TITLE
Fix eas.json: remove unsupported cli.packageManager field

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -1,7 +1,6 @@
 {
   "cli": {
-    "version": ">= 16.0.0",
-    "packageManager": "bun"
+    "version": ">= 16.0.0"
   },
   "build": {
     "development": {


### PR DESCRIPTION
## Summary

- `eas.json` の `cli.packageManager` フィールドが最新 EAS CLI で無効になっており、EAS Build ワークフローが失敗していたため削除

## Test plan

- [ ] main マージ後の EAS Build ワークフローが green になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)