### PR TITLE
Use macos-14 runner for iOS build (Expo 55 / Swift 6 workaround)

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-ios:
     name: Build iOS (Preview)
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

- iOS ビルドのランナーを `macos-latest`（macOS 15 / Xcode 16 / Swift 6）から `macos-14`（Xcode 15 / Swift 5）に変更
- Expo SDK 55 が Swift 6 の strict concurrency に未対応なため、Expo 56 リリースまでの暫定対応

## Test plan

- [ ] main マージ後に EAS Build（iOS・Android）が green になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)