### PR TITLE
feat: 複数画像の一括選択・バッチ処理に対応

### DIFF
--- a/__mocks__/expo-crypto.ts
+++ b/__mocks__/expo-crypto.ts
@@ -1,0 +1,8 @@
+/**
+ * Jest manual mock for expo-crypto.
+ * expo-crypto はネイティブモジュールのため Jest（Node.js 環境）では動作しない。
+ * Node.js 組み込みの crypto モジュールで同等の API を提供する。
+ */
+import { randomUUID as nodeRandomUUID } from 'crypto'
+
+export const randomUUID = (): string => nodeRandomUUID()

--- a/__mocks__/expo-sqlite.ts
+++ b/__mocks__/expo-sqlite.ts
@@ -1,0 +1,65 @@
+/**
+ * Jest manual mock for expo-sqlite.
+ * expo-sqlite はネイティブモジュールのため Jest（Node.js 環境）では動作しない。
+ * このモックは better-sqlite3 のインメモリ DB で同等の API を提供し、
+ * shared/db の実装をそのままテストできるようにする。
+ *
+ * __mocks__ ディレクトリに配置することで Jest が自動的に使用する（jest.mock('expo-sqlite') 不要）。
+ */
+import Database from 'better-sqlite3'
+
+type BindParam = string | number | null
+
+// Jest ワーカー（＝テストファイル）ごとに独立したインメモリ DB を作成する。
+const internalDb = new Database(':memory:')
+
+class MockSQLiteDatabase {
+  execAsync(sql: string): Promise<void> {
+    internalDb.exec(sql)
+    return Promise.resolve()
+  }
+
+  withTransactionAsync(fn: () => Promise<void>): Promise<void> {
+    return fn()
+  }
+
+  getAllAsync<T>(sql: string, params?: BindParam[]): Promise<T[]> {
+    const stmt = internalDb.prepare(sql)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = (params != null ? stmt.all(...(params as any[])) : stmt.all()) as T[]
+    return Promise.resolve(rows)
+  }
+
+  getFirstAsync<T>(sql: string, params?: BindParam[]): Promise<T | null> {
+    const stmt = internalDb.prepare(sql)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const row = (params != null ? stmt.get(...(params as any[])) : stmt.get()) as T | undefined
+    return Promise.resolve(row ?? null)
+  }
+
+  runAsync(sql: string, params?: BindParam[]): Promise<void> {
+    const stmt = internalDb.prepare(sql)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (params != null) stmt.run(...(params as any[]))
+    else stmt.run()
+    return Promise.resolve()
+  }
+}
+
+const mockDb = new MockSQLiteDatabase()
+
+export function openDatabaseAsync(_name: string): Promise<MockSQLiteDatabase> {
+  return Promise.resolve(mockDb)
+}
+
+/**
+ * テスト用ヘルパー: すべてのアプリケーションテーブルの行を削除する。
+ * jest.setup.ts の global beforeEach から各テスト前に自動呼び出しされる。
+ */
+export function __resetDatabase(): void {
+  try {
+    internalDb.exec('DELETE FROM embeddings; DELETE FROM persons;')
+  } catch {
+    // 最初のマイグレーション実行前はテーブルが存在しない場合がある
+  }
+}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,36 +8,46 @@ export default function HomeScreen() {
   const router = useRouter()
 
   const handlePickImage = useCallback(async () => {
-    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync()
-    if (status !== 'granted') {
-      Alert.alert('権限が必要です', 'フォトライブラリへのアクセスを許可してください')
-      return
-    }
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
-      quality: 1,
-      allowsMultipleSelection: true,
-      selectionLimit: 20,
-    })
-    if (!result.canceled && result.assets.length > 0) {
-      const uris = result.assets.map((a) => a.uri)
-      router.push({
-        pathname: '/process/batch',
-        params: { uris: encodeURIComponent(JSON.stringify(uris)) },
+    try {
+      const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync()
+      if (status !== 'granted') {
+        Alert.alert('権限が必要です', 'フォトライブラリへのアクセスを許可してください')
+        return
+      }
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        quality: 1,
+        allowsMultipleSelection: true,
+        selectionLimit: 20,
       })
+      if (!result.canceled && result.assets.length > 0) {
+        const uris = result.assets.map((a) => a.uri)
+        router.push({
+          pathname: '/process/batch',
+          params: { uris: encodeURIComponent(JSON.stringify(uris)) },
+        })
+      }
+    } catch (e: unknown) {
+      console.error('[HomeScreen] launchImageLibraryAsync failed', { error: e })
+      Alert.alert('エラー', '画像を選択できませんでした。もう一度お試しください。')
     }
   }, [router])
 
   const handleCamera = useCallback(async () => {
-    const { status } = await ImagePicker.requestCameraPermissionsAsync()
-    if (status !== 'granted') {
-      Alert.alert('権限が必要です', 'カメラへのアクセスを許可してください')
-      return
-    }
-    const result = await ImagePicker.launchCameraAsync({ quality: 1 })
-    if (!result.canceled && result.assets.length > 0) {
-      const uri = result.assets[0].uri
-      router.push({ pathname: '/process/[imageId]', params: { imageId: encodeURIComponent(uri) } })
+    try {
+      const { status } = await ImagePicker.requestCameraPermissionsAsync()
+      if (status !== 'granted') {
+        Alert.alert('権限が必要です', 'カメラへのアクセスを許可してください')
+        return
+      }
+      const result = await ImagePicker.launchCameraAsync({ quality: 1 })
+      if (!result.canceled && result.assets.length > 0) {
+        const uri = result.assets[0].uri
+        router.push({ pathname: '/process/[imageId]', params: { imageId: encodeURIComponent(uri) } })
+      }
+    } catch (e: unknown) {
+      console.error('[HomeScreen] launchCameraAsync failed', { error: e })
+      Alert.alert('エラー', '写真を撮影できませんでした。もう一度お試しください。')
     }
   }, [router])
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -9,13 +9,8 @@ export default function HomeScreen() {
 
   const handlePickImage = useCallback(async () => {
     try {
-      const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync()
-      if (status !== 'granted') {
-        Alert.alert('権限が必要です', 'フォトライブラリへのアクセスを許可してください')
-        return
-      }
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: 'images',
         quality: 1,
         allowsMultipleSelection: true,
         selectionLimit: 20,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -16,10 +16,15 @@ export default function HomeScreen() {
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       quality: 1,
+      allowsMultipleSelection: true,
+      selectionLimit: 20,
     })
     if (!result.canceled && result.assets.length > 0) {
-      const uri = result.assets[0].uri
-      router.push({ pathname: '/process/[imageId]', params: { imageId: encodeURIComponent(uri) } })
+      const uris = result.assets.map((a) => a.uri)
+      router.push({
+        pathname: '/process/batch',
+        params: { uris: encodeURIComponent(JSON.stringify(uris)) },
+      })
     }
   }, [router])
 

--- a/app/process/batch.tsx
+++ b/app/process/batch.tsx
@@ -12,7 +12,8 @@ export default function BatchProcessScreen() {
     try {
       const raw = Array.isArray(urisParam) ? urisParam[0] : urisParam
       return JSON.parse(decodeURIComponent(raw ?? '[]'))
-    } catch {
+    } catch (e) {
+      console.error('[BatchProcessScreen] Failed to parse uris param', { urisParam, error: e })
       return []
     }
   }, [urisParam])
@@ -22,14 +23,23 @@ export default function BatchProcessScreen() {
   // hasStarted で二重実行を防ぐ（ナビゲーション状態復元時の再マウントを含む）
   const hasStarted = useRef(false)
   useEffect(() => {
-    if (uris.length > 0 && !hasStarted.current) {
+    if (uris.length === 0) {
+      // URI のパース失敗など想定外の状態。ユーザーを元の画面に戻す
+      router.back()
+      return
+    }
+    if (!hasStarted.current) {
       hasStarted.current = true
       processImages(uris)
     }
-  }, [uris, processImages])
+  }, [uris, processImages, router])
 
   const handleSelectNew = () => {
     router.back()
+  }
+
+  const handleRetry = () => {
+    processImages(uris)
   }
 
   const progressMessage =
@@ -44,9 +54,11 @@ export default function BatchProcessScreen() {
       {error && (
         <View style={styles.errorContainer}>
           <Text style={styles.errorText}>処理に失敗しました</Text>
-          <Text style={styles.errorDetail}>{error.message}</Text>
-          <TouchableOpacity style={styles.retryButton} onPress={handleSelectNew}>
-            <Text style={styles.retryText}>別の画像を選択</Text>
+          <TouchableOpacity style={styles.primaryButton} onPress={handleRetry}>
+            <Text style={styles.primaryButtonText}>再試行</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.secondaryButton} onPress={handleSelectNew}>
+            <Text style={styles.secondaryButtonText}>別の画像を選択</Text>
           </TouchableOpacity>
         </View>
       )}
@@ -65,14 +77,19 @@ const styles = StyleSheet.create({
     padding: 32,
     gap: 12,
   },
-  errorText: { fontSize: 18, fontWeight: '600', color: '#FF3B30', textAlign: 'center' },
-  errorDetail: { fontSize: 13, color: '#aaa', textAlign: 'center' },
-  retryButton: {
-    marginTop: 16,
+  errorText: { fontSize: 18, fontWeight: '600', color: '#FF3B30', textAlign: 'center', marginBottom: 8 },
+  primaryButton: {
     backgroundColor: '#007AFF',
     paddingVertical: 12,
-    paddingHorizontal: 24,
+    paddingHorizontal: 32,
     borderRadius: 10,
+    width: '100%',
+    alignItems: 'center',
   },
-  retryText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  primaryButtonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  secondaryButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+  },
+  secondaryButtonText: { color: '#8E8E93', fontSize: 15 },
 })

--- a/app/process/batch.tsx
+++ b/app/process/batch.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef } from 'react'
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native'
+import { View, Text, StyleSheet, TouchableOpacity, Alert } from 'react-native'
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
 import { useProcessImages, ProcessBatchResultView } from '@/features/image-processing'
 import { LoadingOverlay } from '@/shared/ui'
@@ -24,7 +24,8 @@ export default function BatchProcessScreen() {
   const hasStarted = useRef(false)
   useEffect(() => {
     if (uris.length === 0) {
-      // URI のパース失敗など想定外の状態。ユーザーを元の画面に戻す
+      // URI のパース失敗など想定外の状態。通知してから元の画面に戻す
+      Alert.alert('エラー', '処理する画像を取得できませんでした。もう一度お試しください。')
       router.back()
       return
     }
@@ -54,7 +55,12 @@ export default function BatchProcessScreen() {
       {error && (
         <View style={styles.errorContainer}>
           <Text style={styles.errorText}>処理に失敗しました</Text>
-          <TouchableOpacity style={styles.primaryButton} onPress={handleRetry}>
+          <Text style={styles.errorDetail}>{error.message}</Text>
+          <TouchableOpacity
+            style={[styles.primaryButton, isPending && styles.disabledButton]}
+            onPress={handleRetry}
+            disabled={isPending}
+          >
             <Text style={styles.primaryButtonText}>再試行</Text>
           </TouchableOpacity>
           <TouchableOpacity style={styles.secondaryButton} onPress={handleSelectNew}>
@@ -77,7 +83,9 @@ const styles = StyleSheet.create({
     padding: 32,
     gap: 12,
   },
-  errorText: { fontSize: 18, fontWeight: '600', color: '#FF3B30', textAlign: 'center', marginBottom: 8 },
+  errorText: { fontSize: 18, fontWeight: '600', color: '#FF3B30', textAlign: 'center' },
+  errorDetail: { fontSize: 13, color: '#8E8E93', textAlign: 'center', marginBottom: 8 },
+  disabledButton: { opacity: 0.5 },
   primaryButton: {
     backgroundColor: '#007AFF',
     paddingVertical: 12,

--- a/app/process/batch.tsx
+++ b/app/process/batch.tsx
@@ -9,20 +9,31 @@ export default function BatchProcessScreen() {
   const router = useRouter()
 
   const uris = useMemo<string[]>(() => {
+    const raw = Array.isArray(urisParam) ? urisParam[0] : urisParam
+    if (!raw) {
+      console.error('[BatchProcessScreen] uris param is missing', { urisParam })
+      return []
+    }
     try {
-      const raw = Array.isArray(urisParam) ? urisParam[0] : urisParam
-      return JSON.parse(decodeURIComponent(raw ?? '[]'))
+      const parsed: unknown = JSON.parse(decodeURIComponent(raw))
+      if (!Array.isArray(parsed)) {
+        console.error('[BatchProcessScreen] uris param parsed to non-array', { parsed, urisParam })
+        return []
+      }
+      return parsed as string[]
     } catch (e) {
       console.error('[BatchProcessScreen] Failed to parse uris param', { urisParam, error: e })
       return []
     }
   }, [urisParam])
 
-  const { mutate: processImages, isPending, data: results, error, progress } = useProcessImages()
+  const { mutate: processImages, reset: resetMutation, isPending, data: results, error, progress } = useProcessImages()
 
   // hasStarted で二重実行を防ぐ（ナビゲーション状態復元時の再マウントを含む）
   const hasStarted = useRef(false)
   useEffect(() => {
+    // urisParam が undefined の場合はまだ Expo Router がパラメータをハイドレート中のため待機する
+    if (urisParam == null) return
     if (uris.length === 0) {
       // URI のパース失敗など想定外の状態。通知してから元の画面に戻す
       Alert.alert('エラー', '処理する画像を取得できませんでした。もう一度お試しください。')
@@ -33,13 +44,15 @@ export default function BatchProcessScreen() {
       hasStarted.current = true
       processImages(uris)
     }
-  }, [uris, processImages, router])
+  }, [uris, urisParam, processImages, router])
 
   const handleSelectNew = () => {
     router.back()
   }
 
   const handleRetry = () => {
+    if (isPending) return
+    resetMutation()
     processImages(uris)
   }
 
@@ -55,7 +68,7 @@ export default function BatchProcessScreen() {
       {error && (
         <View style={styles.errorContainer}>
           <Text style={styles.errorText}>処理に失敗しました</Text>
-          <Text style={styles.errorDetail}>{error.message}</Text>
+          <Text style={styles.errorDetail}>画像処理の準備に失敗しました。アプリを再起動してもう一度お試しください。</Text>
           <TouchableOpacity
             style={[styles.primaryButton, isPending && styles.disabledButton]}
             onPress={handleRetry}

--- a/app/process/batch.tsx
+++ b/app/process/batch.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useMemo, useRef } from 'react'
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native'
+import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
+import { useProcessImages, ProcessBatchResultView } from '@/features/image-processing'
+import { LoadingOverlay } from '@/shared/ui'
+
+export default function BatchProcessScreen() {
+  const { uris: urisParam } = useLocalSearchParams<{ uris: string }>()
+  const router = useRouter()
+
+  const uris = useMemo<string[]>(() => {
+    try {
+      const raw = Array.isArray(urisParam) ? urisParam[0] : urisParam
+      return JSON.parse(decodeURIComponent(raw ?? '[]'))
+    } catch {
+      return []
+    }
+  }, [urisParam])
+
+  const { mutate: processImages, isPending, data: results, error, progress } = useProcessImages()
+
+  // hasStarted で二重実行を防ぐ（ナビゲーション状態復元時の再マウントを含む）
+  const hasStarted = useRef(false)
+  useEffect(() => {
+    if (uris.length > 0 && !hasStarted.current) {
+      hasStarted.current = true
+      processImages(uris)
+    }
+  }, [uris, processImages])
+
+  const handleSelectNew = () => {
+    router.back()
+  }
+
+  const progressMessage =
+    progress.total > 0 ? `${progress.current} / ${progress.total} 枚処理中...` : '処理中...'
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ headerShown: true, title: '処理結果', headerBackTitle: '戻る' }} />
+
+      {isPending && <LoadingOverlay message={progressMessage} />}
+
+      {error && (
+        <View style={styles.errorContainer}>
+          <Text style={styles.errorText}>処理に失敗しました</Text>
+          <Text style={styles.errorDetail}>{error.message}</Text>
+          <TouchableOpacity style={styles.retryButton} onPress={handleSelectNew}>
+            <Text style={styles.retryText}>別の画像を選択</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {results && <ProcessBatchResultView results={results} onSelectNew={handleSelectNew} />}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#000' },
+  errorContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    gap: 12,
+  },
+  errorText: { fontSize: 18, fontWeight: '600', color: '#FF3B30', textAlign: 'center' },
+  errorDetail: { fontSize: 13, color: '#aaa', textAlign: 'center' },
+  retryButton: {
+    marginTop: 16,
+    backgroundColor: '#007AFF',
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 10,
+  },
+  retryText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+})

--- a/bun.lock
+++ b/bun.lock
@@ -32,9 +32,11 @@
       "devDependencies": {
         "@testing-library/jest-native": "^5.4.3",
         "@testing-library/react-native": "^13.3.3",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/jest": "~29",
         "@types/react": "~19.2.10",
         "@types/uuid": "^11.0.0",
+        "better-sqlite3": "^12.8.0",
         "eslint": "9",
         "eslint-config-expo": "^55.0.0",
         "jest": "~29",
@@ -44,6 +46,7 @@
     },
   },
   "trustedDependencies": [
+    "better-sqlite3",
     "@shopify/react-native-skia",
   ],
   "packages": {
@@ -499,6 +502,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
@@ -689,7 +694,13 @@
 
     "better-opn": ["better-opn@3.0.2", "", { "dependencies": { "open": "^8.0.4" } }, "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ=="],
 
+    "better-sqlite3": ["better-sqlite3@12.8.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ=="],
+
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "bplist-creator": ["bplist-creator@0.1.0", "", { "dependencies": { "stream-buffers": "2.2.x" } }, "sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg=="],
 
@@ -702,6 +713,8 @@
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -724,6 +737,8 @@
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "char-regex": ["char-regex@2.0.2", "", {}, "sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "chrome-launcher": ["chrome-launcher@0.15.2", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^1.0.0" }, "bin": { "print-chrome-path": "bin/print-chrome-path.js" } }, "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ=="],
 
@@ -795,7 +810,11 @@
 
     "decode-uri-component": ["decode-uri-component@0.2.2", "", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
     "dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -840,6 +859,8 @@
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -913,6 +934,8 @@
 
     "exit": ["exit@0.1.2", "", {}, "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ=="],
 
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
     "expect": ["expect@29.7.0", "", { "dependencies": { "@jest/expect-utils": "^29.7.0", "jest-get-type": "^29.6.3", "jest-matcher-utils": "^29.7.0", "jest-message-util": "^29.7.0", "jest-util": "^29.7.0" } }, "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw=="],
 
     "expo": ["expo@55.0.8", "", { "dependencies": { "@babel/runtime": "^7.20.0", "@expo/cli": "55.0.18", "@expo/config": "~55.0.10", "@expo/config-plugins": "~55.0.7", "@expo/devtools": "55.0.2", "@expo/fingerprint": "0.16.6", "@expo/local-build-cache-provider": "55.0.7", "@expo/log-box": "55.0.7", "@expo/metro": "~54.2.0", "@expo/metro-config": "55.0.11", "@expo/vector-icons": "^15.0.2", "@ungap/structured-clone": "^1.3.0", "babel-preset-expo": "~55.0.12", "expo-asset": "~55.0.10", "expo-constants": "~55.0.9", "expo-file-system": "~55.0.11", "expo-font": "~55.0.4", "expo-keep-awake": "~55.0.4", "expo-modules-autolinking": "55.0.11", "expo-modules-core": "55.0.17", "pretty-format": "^29.7.0", "react-refresh": "^0.14.2", "whatwg-url-minimum": "^0.1.1" }, "peerDependencies": { "@expo/dom-webview": "*", "@expo/metro-runtime": "*", "react": "*", "react-native": "*", "react-native-webview": "*" }, "optionalPeers": ["@expo/dom-webview", "@expo/metro-runtime", "react-native-webview"], "bin": { "expo": "bin/cli", "fingerprint": "bin/fingerprint", "expo-modules-autolinking": "bin/autolinking" } }, "sha512-sziDGiDmeRmaSpFwMuSxFhr4vfWrQS1UgVXSTovsUDY0ximABzYdnF5L2OwtD8zjtIww8x2oJGmD6mKS+AoVsw=="],
@@ -973,6 +996,8 @@
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "filter-obj": ["filter-obj@1.1.0", "", {}, "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="],
@@ -994,6 +1019,8 @@
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
@@ -1026,6 +1053,8 @@
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
     "getenv": ["getenv@2.0.0", "", {}, "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -1075,6 +1104,8 @@
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "image-size": ["image-size@1.2.1", "", { "dependencies": { "queue": "6.0.2" }, "bin": { "image-size": "bin/image-size.js" } }, "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw=="],
@@ -1090,6 +1121,8 @@
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
@@ -1365,6 +1398,8 @@
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
@@ -1375,17 +1410,23 @@
 
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "multitars": ["multitars@0.2.4", "", {}, "sha512-XgLbg1HHchFauMCQPRwMj6MSyDd5koPlTA1hM3rUFkeXzGpjU/I9fP3to7yrObE9jcN8ChIOQGrM0tV0kUZaKg=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
+    "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
 
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 
@@ -1481,6 +1522,8 @@
 
     "postcss": ["postcss@8.4.49", "", { "dependencies": { "nanoid": "^3.3.7", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
@@ -1497,6 +1540,8 @@
 
     "psl": ["psl@1.15.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w=="],
 
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
@@ -1508,6 +1553,8 @@
     "queue": ["queue@6.0.2", "", { "dependencies": { "inherits": "~2.0.3" } }, "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "react": ["react@19.2.0", "", {}, "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="],
 
@@ -1548,6 +1595,8 @@
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "react-test-renderer": ["react-test-renderer@19.2.0", "", { "dependencies": { "react-is": "^19.2.0", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
@@ -1641,6 +1690,10 @@
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
     "simple-plist": ["simple-plist@1.3.1", "", { "dependencies": { "bplist-creator": "0.1.0", "bplist-parser": "0.3.1", "plist": "^3.0.5" } }, "sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw=="],
 
     "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
@@ -1697,6 +1750,8 @@
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
 
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
@@ -1716,6 +1771,10 @@
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "terminal-link": ["terminal-link@2.1.1", "", { "dependencies": { "ansi-escapes": "^4.2.1", "supports-hyperlinks": "^2.0.0" } }, "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ=="],
 
@@ -1744,6 +1803,8 @@
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -1792,6 +1853,8 @@
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
@@ -2051,6 +2114,8 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "node-abi/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "node-exports-info/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "npm-package-arg/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
@@ -2066,6 +2131,8 @@
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "react-native/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,8 @@
+/**
+ * Jest グローバルセットアップ。
+ * 各テストの前にインメモリ SQLite DB の全行を削除し、テスト間のデータ汚染を防ぐ。
+ */
+beforeEach(() => {
+  const sqliteModule = require('expo-sqlite') as { __resetDatabase?: () => void }
+  sqliteModule.__resetDatabase?.()
+})

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "jest": {
     "preset": "jest-expo",
+    "setupFilesAfterEnv": ["<rootDir>/jest.setup.ts"],
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@shopify/react-native-skia|@sentry/react-native|native-base|react-native-svg|uuid)"
     ],
@@ -49,9 +50,11 @@
   "devDependencies": {
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.3.3",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/jest": "~29",
     "@types/react": "~19.2.10",
     "@types/uuid": "^11.0.0",
+    "better-sqlite3": "^12.8.0",
     "eslint": "9",
     "eslint-config-expo": "^55.0.0",
     "jest": "~29",
@@ -59,6 +62,7 @@
     "typescript": "~5.9.2"
   },
   "trustedDependencies": [
-    "@shopify/react-native-skia"
+    "@shopify/react-native-skia",
+    "better-sqlite3"
   ]
 }

--- a/src/features/image-processing/index.ts
+++ b/src/features/image-processing/index.ts
@@ -1,2 +1,5 @@
 export { useProcessImage } from './model/useProcessImage'
+export { useProcessImages } from './model/useProcessImages'
+export type { ImageProcessResult, ProcessProgress } from './model/useProcessImages'
 export { ProcessResultView } from './ui/ProcessResultView'
+export { ProcessBatchResultView } from './ui/ProcessBatchResultView'

--- a/src/features/image-processing/model/__tests__/processImage.test.ts
+++ b/src/features/image-processing/model/__tests__/processImage.test.ts
@@ -82,6 +82,26 @@ describe('processImage', () => {
       expect(Mosaic.apply).not.toHaveBeenCalled()
       expect(result).toBe('file://original.jpg')
     })
+
+    it('blurs face when matched person is among multiple registered persons', async () => {
+      const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
+      const { cosineSimilarity } = require('@/shared/lib')
+
+      FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
+      FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+
+      // p1: 低一致(0.3)、p2: 高一致(0.9) → p2 が一致するのでモザイク対象
+      cosineSimilarity
+        .mockReturnValueOnce(0.3)  // face vs p1
+        .mockReturnValueOnce(0.9)  // face vs p2
+
+      await processImage('file://original.jpg', [
+        makeStoredEmbedding('1', 'p1'),
+        makeStoredEmbedding('2', 'p2'),
+      ])
+
+      expect(Mosaic.apply).toHaveBeenCalled()
+    })
   })
 
   describe('bounding box coordinate scaling', () => {
@@ -101,35 +121,59 @@ describe('processImage', () => {
         { x: 5, y: 10, width: 25, height: 30 },
       ])
     })
-
-    it('passes resized uri (not original) to Mosaic.apply', async () => {
-      const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
-      const { cosineSimilarity, resizeForMosaic } = require('@/shared/lib')
-
-      FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
-      FaceNet.extractAll.mockResolvedValue([mockEmbedding])
-      cosineSimilarity.mockReturnValue(0.95)
-      resizeForMosaic.mockResolvedValue({ uri: 'file://resized.jpg', scale: 1 })
-
-      await processImage('file://original.jpg', [makeStoredEmbedding('1', 'p1')])
-
-      expect(Mosaic.apply).toHaveBeenCalledWith('file://resized.jpg', expect.anything())
-    })
   })
 
   describe('preloadedEmbeddings', () => {
-    it('uses preloaded embeddings and skips DB call', async () => {
-      const { FaceDetector, FaceNet } = require('@/shared/native')
+    it('uses preloaded embeddings for matching without calling DB', async () => {
+      const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
       const { getAllEmbeddings } = require('@/shared/db')
       const { cosineSimilarity } = require('@/shared/lib')
 
       FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
       FaceNet.extractAll.mockResolvedValue([mockEmbedding])
-      cosineSimilarity.mockReturnValue(0.3)
+      cosineSimilarity.mockReturnValue(0.95) // 一致 → モザイク適用
 
       await processImage('file://original.jpg', [makeStoredEmbedding('1', 'p1')])
 
       expect(getAllEmbeddings).not.toHaveBeenCalled()
+      expect(Mosaic.apply).toHaveBeenCalled() // preloadedEmbeddings が実際に照合に使われた証拠
+    })
+  })
+
+  describe('robustness', () => {
+    it('does not throw when FaceNet returns fewer embeddings than detected faces', async () => {
+      const { FaceDetector, FaceNet } = require('@/shared/native')
+      const { cosineSimilarity } = require('@/shared/lib')
+
+      // 2つの顔が検出されたが FaceNet が1つしか embedding を返さない
+      FaceDetector.detect.mockResolvedValue([
+        { x: 0, y: 0, width: 50, height: 50 },
+        { x: 100, y: 0, width: 50, height: 50 },
+      ])
+      FaceNet.extractAll.mockResolvedValue([mockEmbedding]) // 2顔に対して1件のみ
+      cosineSimilarity.mockReturnValue(0.3) // 一致なし
+
+      // faceEmbeddings[1] === undefined の顔は !faceEmbedding ガードでスキップ。エラーにならない
+      await expect(
+        processImage('file://original.jpg', [makeStoredEmbedding('1', 'p1')])
+      ).resolves.toBe('file://original.jpg')
+    })
+
+    it('skips corrupt embedding records and continues matching', async () => {
+      const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
+      const { cosineSimilarity } = require('@/shared/lib')
+
+      FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
+      FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+      cosineSimilarity.mockReturnValue(0.95) // 有効なレコードは一致
+
+      const corruptRecord = { id: 'bad', person_id: 'p1', embedding: 'INVALID_JSON', source_uri: 'u', created_at: '', updated_at: '' }
+      const validRecord = makeStoredEmbedding('good', 'p2')
+
+      // corrupt レコードはスキップ、valid レコードで照合が成功する
+      await processImage('file://original.jpg', [corruptRecord, validRecord])
+
+      expect(Mosaic.apply).toHaveBeenCalled()
     })
   })
 })

--- a/src/features/image-processing/model/__tests__/processImage.test.ts
+++ b/src/features/image-processing/model/__tests__/processImage.test.ts
@@ -1,5 +1,9 @@
 import { processImage } from '../processImage'
 import { FACE_SIMILARITY_THRESHOLD as THRESHOLD } from '@/shared/config'
+import { insertPerson, insertEmbedding } from '@/shared/db'
+import * as dbModule from '@/shared/db'
+
+jest.mock('@/shared/db', () => ({ __esModule: true, ...jest.requireActual('@/shared/db') }))
 
 const mockEmbedding = Array(128).fill(0.5)
 
@@ -9,27 +13,38 @@ jest.mock('@/shared/native', () => ({
   Mosaic: { apply: jest.fn().mockResolvedValue('file://blurred.jpg') },
 }))
 
-jest.mock('@/shared/db', () => ({
-  getAllEmbeddings: jest.fn(),
-}))
-
 jest.mock('@/shared/lib', () => ({
   cosineSimilarity: jest.fn(),
   cropFace: jest.fn().mockImplementation((_uri, _box) => Promise.resolve('file://cropped.jpg')),
   resizeForMosaic: jest.fn().mockResolvedValue({ uri: 'file://resized.jpg', scale: 1 }),
 }))
 
-const makeStoredEmbedding = (id: string, personId: string) => ({
-  id,
-  person_id: personId,
-  embedding: JSON.stringify(mockEmbedding),
-  source_uri: 'u',
-  created_at: '',
-  updated_at: '',
-})
+const NOW = '2026-01-01T00:00:00.000Z'
+
+function makeStoredEmbedding(id: string, personId: string) {
+  return {
+    id,
+    person_id: personId,
+    embedding: JSON.stringify(mockEmbedding),
+    source_uri: 'u',
+    created_at: NOW,
+    updated_at: NOW,
+  }
+}
+
+async function seedEmbedding(id: string, personId: string) {
+  await insertPerson({ id: personId, name: 'Test', memo: null, created_at: NOW, updated_at: NOW })
+  await insertEmbedding(makeStoredEmbedding(id, personId))
+}
 
 describe('processImage', () => {
-  beforeEach(() => jest.clearAllMocks())
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
 
   it('returns original uri immediately when no faces are detected', async () => {
     const { FaceDetector, FaceNet } = require('@/shared/native')
@@ -150,24 +165,24 @@ describe('processImage', () => {
 
   describe('preloadedEmbeddings', () => {
     it('calls getAllEmbeddings when preloadedEmbeddings is not provided', async () => {
+      await seedEmbedding('1', 'p1')
       const { FaceDetector, FaceNet } = require('@/shared/native')
-      const { getAllEmbeddings } = require('@/shared/db')
       const { cosineSimilarity } = require('@/shared/lib')
+      const getAllEmbeddingsSpy = jest.spyOn(dbModule, 'getAllEmbeddings')
 
       FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
       FaceNet.extractAll.mockResolvedValue([mockEmbedding])
-      getAllEmbeddings.mockResolvedValue([makeStoredEmbedding('1', 'p1')])
       cosineSimilarity.mockReturnValue(0.3)
 
       await processImage('file://original.jpg') // 第2引数なし
 
-      expect(getAllEmbeddings).toHaveBeenCalledTimes(1)
+      expect(getAllEmbeddingsSpy).toHaveBeenCalledTimes(1)
     })
 
     it('uses preloaded embeddings for matching without calling DB', async () => {
       const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
-      const { getAllEmbeddings } = require('@/shared/db')
       const { cosineSimilarity } = require('@/shared/lib')
+      const getAllEmbeddingsSpy = jest.spyOn(dbModule, 'getAllEmbeddings')
 
       FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
       FaceNet.extractAll.mockResolvedValue([mockEmbedding])
@@ -175,7 +190,7 @@ describe('processImage', () => {
 
       await processImage('file://original.jpg', [makeStoredEmbedding('1', 'p1')])
 
-      expect(getAllEmbeddings).not.toHaveBeenCalled()
+      expect(getAllEmbeddingsSpy).not.toHaveBeenCalled()
       expect(Mosaic.apply).toHaveBeenCalled() // preloadedEmbeddings が実際に照合に使われた証拠
     })
   })

--- a/src/features/image-processing/model/__tests__/processImage.test.ts
+++ b/src/features/image-processing/model/__tests__/processImage.test.ts
@@ -1,0 +1,135 @@
+import { processImage } from '../processImage'
+import { FACE_SIMILARITY_THRESHOLD as THRESHOLD } from '@/shared/config'
+
+const mockEmbedding = Array(128).fill(0.5)
+
+jest.mock('@/shared/native', () => ({
+  FaceDetector: { detect: jest.fn() },
+  FaceNet: { extractAll: jest.fn() },
+  Mosaic: { apply: jest.fn().mockResolvedValue('file://blurred.jpg') },
+}))
+
+jest.mock('@/shared/db', () => ({
+  getAllEmbeddings: jest.fn(),
+}))
+
+jest.mock('@/shared/lib', () => ({
+  cosineSimilarity: jest.fn(),
+  cropFace: jest.fn().mockImplementation((_uri, _box) => Promise.resolve('file://cropped.jpg')),
+  resizeForMosaic: jest.fn().mockResolvedValue({ uri: 'file://resized.jpg', scale: 1 }),
+}))
+
+const makeStoredEmbedding = (id: string, personId: string) => ({
+  id,
+  person_id: personId,
+  embedding: JSON.stringify(mockEmbedding),
+  source_uri: 'u',
+  created_at: '',
+  updated_at: '',
+})
+
+describe('processImage', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  describe('any-match semantics (CLAUDE.md 照合方針)', () => {
+    it('blurs face when any single embedding exceeds threshold', async () => {
+      const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
+      const { cosineSimilarity } = require('@/shared/lib')
+
+      FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
+      FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+
+      // 1人につき2枚登録: 1枚は高一致(0.9)・1枚は低一致(0.3) → any-match なのでモザイク対象
+      // 平均(0.6)は THRESHOLD と等しく、平均判定なら対象外になってしまう
+      cosineSimilarity.mockReturnValueOnce(0.9).mockReturnValueOnce(0.3)
+
+      await processImage('file://original.jpg', [
+        makeStoredEmbedding('1', 'p1'),
+        makeStoredEmbedding('2', 'p1'),
+      ])
+
+      expect(Mosaic.apply).toHaveBeenCalled()
+    })
+
+    it('does not blur face when no embedding exceeds threshold', async () => {
+      const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
+      const { cosineSimilarity } = require('@/shared/lib')
+
+      FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
+      FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+
+      cosineSimilarity.mockReturnValueOnce(0.4).mockReturnValueOnce(0.5)
+
+      const result = await processImage('file://original.jpg', [
+        makeStoredEmbedding('1', 'p1'),
+        makeStoredEmbedding('2', 'p1'),
+      ])
+
+      expect(Mosaic.apply).not.toHaveBeenCalled()
+      expect(result).toBe('file://original.jpg')
+    })
+
+    it('does not blur when similarity equals threshold exactly (strict >)', async () => {
+      const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
+      const { cosineSimilarity } = require('@/shared/lib')
+
+      FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
+      FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+      cosineSimilarity.mockReturnValue(THRESHOLD)
+
+      const result = await processImage('file://original.jpg', [makeStoredEmbedding('1', 'p1')])
+
+      expect(Mosaic.apply).not.toHaveBeenCalled()
+      expect(result).toBe('file://original.jpg')
+    })
+  })
+
+  describe('bounding box coordinate scaling', () => {
+    it('scales box coordinates by resizeForMosaic scale factor before passing to Mosaic.apply', async () => {
+      const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
+      const { cosineSimilarity, resizeForMosaic } = require('@/shared/lib')
+
+      const box = { x: 10, y: 20, width: 50, height: 60 }
+      FaceDetector.detect.mockResolvedValue([box])
+      FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+      cosineSimilarity.mockReturnValue(0.95)
+      resizeForMosaic.mockResolvedValue({ uri: 'file://resized.jpg', scale: 0.5 })
+
+      await processImage('file://original.jpg', [makeStoredEmbedding('1', 'p1')])
+
+      expect(Mosaic.apply).toHaveBeenCalledWith('file://resized.jpg', [
+        { x: 5, y: 10, width: 25, height: 30 },
+      ])
+    })
+
+    it('passes resized uri (not original) to Mosaic.apply', async () => {
+      const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
+      const { cosineSimilarity, resizeForMosaic } = require('@/shared/lib')
+
+      FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
+      FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+      cosineSimilarity.mockReturnValue(0.95)
+      resizeForMosaic.mockResolvedValue({ uri: 'file://resized.jpg', scale: 1 })
+
+      await processImage('file://original.jpg', [makeStoredEmbedding('1', 'p1')])
+
+      expect(Mosaic.apply).toHaveBeenCalledWith('file://resized.jpg', expect.anything())
+    })
+  })
+
+  describe('preloadedEmbeddings', () => {
+    it('uses preloaded embeddings and skips DB call', async () => {
+      const { FaceDetector, FaceNet } = require('@/shared/native')
+      const { getAllEmbeddings } = require('@/shared/db')
+      const { cosineSimilarity } = require('@/shared/lib')
+
+      FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
+      FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+      cosineSimilarity.mockReturnValue(0.3)
+
+      await processImage('file://original.jpg', [makeStoredEmbedding('1', 'p1')])
+
+      expect(getAllEmbeddings).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/features/image-processing/model/__tests__/processImage.test.ts
+++ b/src/features/image-processing/model/__tests__/processImage.test.ts
@@ -31,6 +31,31 @@ const makeStoredEmbedding = (id: string, personId: string) => ({
 describe('processImage', () => {
   beforeEach(() => jest.clearAllMocks())
 
+  it('returns original uri immediately when no faces are detected', async () => {
+    const { FaceDetector, FaceNet } = require('@/shared/native')
+
+    FaceDetector.detect.mockResolvedValue([])
+
+    const result = await processImage('file://original.jpg', [makeStoredEmbedding('1', 'p1')])
+
+    expect(result).toBe('file://original.jpg')
+    expect(FaceNet.extractAll).not.toHaveBeenCalled()
+  })
+
+  it('propagates error when Mosaic.apply fails', async () => {
+    const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
+    const { cosineSimilarity } = require('@/shared/lib')
+
+    FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
+    FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+    cosineSimilarity.mockReturnValue(0.95)
+    Mosaic.apply.mockRejectedValueOnce(new Error('mosaic error'))
+
+    await expect(
+      processImage('file://original.jpg', [makeStoredEmbedding('1', 'p1')])
+    ).rejects.toThrow('mosaic error')
+  })
+
   describe('any-match semantics (CLAUDE.md 照合方針)', () => {
     it('blurs face when any single embedding exceeds threshold', async () => {
       const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
@@ -124,6 +149,21 @@ describe('processImage', () => {
   })
 
   describe('preloadedEmbeddings', () => {
+    it('calls getAllEmbeddings when preloadedEmbeddings is not provided', async () => {
+      const { FaceDetector, FaceNet } = require('@/shared/native')
+      const { getAllEmbeddings } = require('@/shared/db')
+      const { cosineSimilarity } = require('@/shared/lib')
+
+      FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
+      FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+      getAllEmbeddings.mockResolvedValue([makeStoredEmbedding('1', 'p1')])
+      cosineSimilarity.mockReturnValue(0.3)
+
+      await processImage('file://original.jpg') // 第2引数なし
+
+      expect(getAllEmbeddings).toHaveBeenCalledTimes(1)
+    })
+
     it('uses preloaded embeddings for matching without calling DB', async () => {
       const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
       const { getAllEmbeddings } = require('@/shared/db')
@@ -141,9 +181,8 @@ describe('processImage', () => {
   })
 
   describe('robustness', () => {
-    it('does not throw when FaceNet returns fewer embeddings than detected faces', async () => {
+    it('throws when FaceNet returns fewer embeddings than detected faces', async () => {
       const { FaceDetector, FaceNet } = require('@/shared/native')
-      const { cosineSimilarity } = require('@/shared/lib')
 
       // 2つの顔が検出されたが FaceNet が1つしか embedding を返さない
       FaceDetector.detect.mockResolvedValue([
@@ -151,12 +190,11 @@ describe('processImage', () => {
         { x: 100, y: 0, width: 50, height: 50 },
       ])
       FaceNet.extractAll.mockResolvedValue([mockEmbedding]) // 2顔に対して1件のみ
-      cosineSimilarity.mockReturnValue(0.3) // 一致なし
 
-      // faceEmbeddings[1] === undefined の顔は !faceEmbedding ガードでスキップ。エラーにならない
+      // embedding 数不一致はサイレントスキップではなく明示的エラーにする（プライバシー保護）
       await expect(
         processImage('file://original.jpg', [makeStoredEmbedding('1', 'p1')])
-      ).resolves.toBe('file://original.jpg')
+      ).rejects.toThrow('FaceNet embedding count mismatch')
     })
 
     it('skips corrupt embedding records and continues matching', async () => {

--- a/src/features/image-processing/model/__tests__/useProcessImage.test.ts
+++ b/src/features/image-processing/model/__tests__/useProcessImage.test.ts
@@ -173,8 +173,8 @@ describe('useProcessImage', () => {
     await waitFor(() => expect(result.current.isError).toBe(true))
   })
 
-  it('enters error state when stored embedding JSON is corrupt', async () => {
-    const { FaceDetector, FaceNet } = require('@/shared/native')
+  it('skips corrupt embedding records and returns original uri gracefully', async () => {
+    const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
     const { getAllEmbeddings } = require('@/shared/db')
 
     FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
@@ -186,6 +186,9 @@ describe('useProcessImage', () => {
     const { result } = renderHook(() => useProcessImage(), { wrapper: makeWrapper() })
     act(() => { result.current.mutate('file://original.jpg') })
 
-    await waitFor(() => expect(result.current.isError).toBe(true))
+    // corrupt レコードはスキップされ処理が継続する（エラーにならない）
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toBe('file://original.jpg') // match なし → 元画像を返す
+    expect(Mosaic.apply).not.toHaveBeenCalled()
   })
 })

--- a/src/features/image-processing/model/__tests__/useProcessImage.test.ts
+++ b/src/features/image-processing/model/__tests__/useProcessImage.test.ts
@@ -19,7 +19,7 @@ jest.mock('@/shared/db', () => ({
 jest.mock('@/shared/lib', () => ({
   cosineSimilarity: jest.fn(),
   cropFace: jest.fn().mockImplementation((_uri, _box) => Promise.resolve('file://cropped.jpg')),
-  resizeForMosaic: jest.fn().mockResolvedValue({ uri: 'file://original.jpg', scale: 1 }),
+  resizeForMosaic: jest.fn().mockResolvedValue({ uri: 'file://resized.jpg', scale: 1 }),
 }))
 
 function makeWrapper() {
@@ -80,7 +80,7 @@ describe('useProcessImage', () => {
     act(() => { result.current.mutate('file://original.jpg') })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(Mosaic.apply).toHaveBeenCalledWith('file://original.jpg', [box])
+    expect(Mosaic.apply).toHaveBeenCalledWith('file://resized.jpg', [box])
     expect(result.current.data).toBe('file://blurred.jpg')
   })
 
@@ -145,7 +145,7 @@ describe('useProcessImage', () => {
     act(() => { result.current.mutate('file://original.jpg') })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(Mosaic.apply).toHaveBeenCalledWith('file://original.jpg', [boxA])
+    expect(Mosaic.apply).toHaveBeenCalledWith('file://resized.jpg', [boxA])
     expect(result.current.data).toBe('file://blurred.jpg')
   })
 

--- a/src/features/image-processing/model/__tests__/useProcessImage.test.ts
+++ b/src/features/image-processing/model/__tests__/useProcessImage.test.ts
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { useProcessImage } from '../useProcessImage'
 import { FACE_SIMILARITY_THRESHOLD as THRESHOLD } from '@/shared/config'
+import { insertPerson, insertEmbedding } from '@/shared/db'
 
 const mockEmbedding = Array(128).fill(0.5)
 
@@ -10,10 +11,6 @@ jest.mock('@/shared/native', () => ({
   FaceDetector: { detect: jest.fn() },
   FaceNet: { extractAll: jest.fn() },
   Mosaic: { apply: jest.fn().mockResolvedValue('file://blurred.jpg') },
-}))
-
-jest.mock('@/shared/db', () => ({
-  getAllEmbeddings: jest.fn(),
 }))
 
 jest.mock('@/shared/lib', () => ({
@@ -28,9 +25,12 @@ function makeWrapper() {
     React.createElement(QueryClientProvider, { client: qc }, children)
 }
 
-const storedEmbedding = [
-  { id: '1', person_id: 'p1', embedding: JSON.stringify(mockEmbedding), source_uri: 'u', created_at: '', updated_at: '' },
-]
+const NOW = '2026-01-01T00:00:00.000Z'
+
+async function seedStoredEmbedding(embeddingData = JSON.stringify(mockEmbedding)) {
+  await insertPerson({ id: 'p1', name: 'Test', memo: null, created_at: NOW, updated_at: NOW })
+  await insertEmbedding({ id: '1', person_id: 'p1', embedding: embeddingData, source_uri: 'u', created_at: NOW, updated_at: NOW })
+}
 
 describe('useProcessImage', () => {
   beforeEach(() => { jest.clearAllMocks() })
@@ -48,13 +48,11 @@ describe('useProcessImage', () => {
 
   it('crops each face before extracting embeddings', async () => {
     const { FaceDetector, FaceNet } = require('@/shared/native')
-    const { getAllEmbeddings } = require('@/shared/db')
     const { cosineSimilarity, cropFace } = require('@/shared/lib')
 
     const box = { x: 10, y: 10, width: 50, height: 50 }
     FaceDetector.detect.mockResolvedValue([box])
     FaceNet.extractAll.mockResolvedValue([mockEmbedding])
-    getAllEmbeddings.mockResolvedValue([])
     cosineSimilarity.mockReturnValue(0.3)
 
     const { result } = renderHook(() => useProcessImage(), { wrapper: makeWrapper() })
@@ -66,14 +64,13 @@ describe('useProcessImage', () => {
   })
 
   it('applies mosaic when similarity is above threshold', async () => {
+    await seedStoredEmbedding()
     const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
-    const { getAllEmbeddings } = require('@/shared/db')
     const { cosineSimilarity } = require('@/shared/lib')
 
     const box = { x: 10, y: 10, width: 50, height: 50 }
     FaceDetector.detect.mockResolvedValue([box])
     FaceNet.extractAll.mockResolvedValue([mockEmbedding])
-    getAllEmbeddings.mockResolvedValue(storedEmbedding)
     cosineSimilarity.mockReturnValue(0.95)
 
     const { result } = renderHook(() => useProcessImage(), { wrapper: makeWrapper() })
@@ -85,14 +82,13 @@ describe('useProcessImage', () => {
   })
 
   it('does not apply mosaic when similarity is below threshold', async () => {
+    await seedStoredEmbedding()
     const { FaceDetector, FaceNet } = require('@/shared/native')
-    const { getAllEmbeddings } = require('@/shared/db')
     const { cosineSimilarity } = require('@/shared/lib')
 
     const box = { x: 10, y: 10, width: 50, height: 50 }
     FaceDetector.detect.mockResolvedValue([box])
     FaceNet.extractAll.mockResolvedValue([mockEmbedding])
-    getAllEmbeddings.mockResolvedValue(storedEmbedding)
     cosineSimilarity.mockReturnValue(0.3)
 
     const { result } = renderHook(() => useProcessImage(), { wrapper: makeWrapper() })
@@ -103,15 +99,13 @@ describe('useProcessImage', () => {
   })
 
   it('does not blur when similarity equals threshold exactly (strict >)', async () => {
-    const { FaceDetector, FaceNet } = require('@/shared/native')
-    const { getAllEmbeddings } = require('@/shared/db')
+    await seedStoredEmbedding()
+    const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
     const { cosineSimilarity } = require('@/shared/lib')
-    const { Mosaic } = require('@/shared/native')
 
     const box = { x: 0, y: 0, width: 100, height: 100 }
     FaceDetector.detect.mockResolvedValue([box])
     FaceNet.extractAll.mockResolvedValue([mockEmbedding])
-    getAllEmbeddings.mockResolvedValue(storedEmbedding)
     cosineSimilarity.mockReturnValue(THRESHOLD) // exactly 0.7
 
     const { result } = renderHook(() => useProcessImage(), { wrapper: makeWrapper() })
@@ -123,8 +117,8 @@ describe('useProcessImage', () => {
   })
 
   it('blurs only matched faces in multi-face image', async () => {
+    await seedStoredEmbedding()
     const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
-    const { getAllEmbeddings } = require('@/shared/db')
     const { cosineSimilarity } = require('@/shared/lib')
 
     const boxA = { x: 0, y: 0, width: 50, height: 50 }
@@ -134,7 +128,6 @@ describe('useProcessImage', () => {
 
     FaceDetector.detect.mockResolvedValue([boxA, boxB])
     FaceNet.extractAll.mockResolvedValue([embeddingA, embeddingB])
-    getAllEmbeddings.mockResolvedValue(storedEmbedding)
 
     // faceA: above threshold → blur; faceB: below threshold → keep
     cosineSimilarity
@@ -161,11 +154,9 @@ describe('useProcessImage', () => {
 
   it('enters error state when FaceNet fails', async () => {
     const { FaceDetector, FaceNet } = require('@/shared/native')
-    const { getAllEmbeddings } = require('@/shared/db')
 
     FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
     FaceNet.extractAll.mockRejectedValue(new Error('inference error'))
-    getAllEmbeddings.mockResolvedValue([])
 
     const { result } = renderHook(() => useProcessImage(), { wrapper: makeWrapper() })
     act(() => { result.current.mutate('file://original.jpg') })
@@ -174,14 +165,12 @@ describe('useProcessImage', () => {
   })
 
   it('skips corrupt embedding records and returns original uri gracefully', async () => {
+    // corrupt な embedding レコードを DB に挿入する
+    await seedStoredEmbedding('INVALID_JSON')
     const { FaceDetector, FaceNet, Mosaic } = require('@/shared/native')
-    const { getAllEmbeddings } = require('@/shared/db')
 
     FaceDetector.detect.mockResolvedValue([{ x: 0, y: 0, width: 50, height: 50 }])
     FaceNet.extractAll.mockResolvedValue([mockEmbedding])
-    getAllEmbeddings.mockResolvedValue([
-      { id: '1', person_id: 'p1', embedding: 'INVALID_JSON', source_uri: 'u', created_at: '', updated_at: '' },
-    ])
 
     const { result } = renderHook(() => useProcessImage(), { wrapper: makeWrapper() })
     act(() => { result.current.mutate('file://original.jpg') })

--- a/src/features/image-processing/model/__tests__/useProcessImages.test.ts
+++ b/src/features/image-processing/model/__tests__/useProcessImages.test.ts
@@ -24,6 +24,10 @@ describe('useProcessImages', () => {
     jest.spyOn(Alert, 'alert')
   })
 
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it('returns success results for all images', async () => {
     const { getAllEmbeddings } = require('@/shared/db')
     const { processImage } = require('../processImage')
@@ -72,7 +76,25 @@ describe('useProcessImages', () => {
     act(() => { result.current.mutate(['file://a.jpg']) })
 
     await waitFor(() => expect(result.current.isError).toBe(true))
-    expect(Alert.alert).toHaveBeenCalledWith('処理エラー', 'db error')
+    expect(Alert.alert).toHaveBeenCalledWith('処理エラー', 'データの読み込みに失敗しました。アプリを再起動してもう一度お試しください。')
+  })
+
+  it('passes preloaded embeddings to processImage for each image in the batch', async () => {
+    const { getAllEmbeddings } = require('@/shared/db')
+    const { processImage } = require('../processImage')
+
+    const storedEmbeddings = [
+      { id: '1', person_id: 'p1', embedding: JSON.stringify(Array(128).fill(0.5)), source_uri: 'u', created_at: '', updated_at: '' },
+    ]
+    getAllEmbeddings.mockResolvedValue(storedEmbeddings)
+    processImage.mockResolvedValue('file://result.jpg')
+
+    const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
+    act(() => { result.current.mutate(['file://a.jpg', 'file://b.jpg']) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(processImage).toHaveBeenCalledWith('file://a.jpg', storedEmbeddings)
+    expect(processImage).toHaveBeenCalledWith('file://b.jpg', storedEmbeddings)
   })
 
   it('calls getAllEmbeddings only once for a batch of images', async () => {
@@ -112,6 +134,28 @@ describe('useProcessImages', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.progress).toEqual({ current: 2, total: 2 })
+  })
+
+  it('resolves as success (not error) even when all images fail', async () => {
+    const { getAllEmbeddings } = require('@/shared/db')
+    const { processImage } = require('../processImage')
+
+    getAllEmbeddings.mockResolvedValue([])
+    processImage
+      .mockRejectedValueOnce(new Error('fail1'))
+      .mockRejectedValueOnce(new Error('fail2'))
+
+    const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
+    act(() => { result.current.mutate(['file://a.jpg', 'file://b.jpg']) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.isError).toBe(false)
+    expect(result.current.data).toEqual([
+      { status: 'error', originalUri: 'file://a.jpg', resultUri: 'file://a.jpg', error: 'fail1' },
+      { status: 'error', originalUri: 'file://b.jpg', resultUri: 'file://b.jpg', error: 'fail2' },
+    ])
+    // 画像単位の全失敗でも onError (Alert) は発火しない
+    expect(Alert.alert).not.toHaveBeenCalled()
   })
 
   it('stores error message as string even for non-Error throws', async () => {

--- a/src/features/image-processing/model/__tests__/useProcessImages.test.ts
+++ b/src/features/image-processing/model/__tests__/useProcessImages.test.ts
@@ -1,0 +1,133 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { Alert } from 'react-native'
+import { useProcessImages } from '../useProcessImages'
+
+jest.mock('@/shared/db', () => ({
+  getAllEmbeddings: jest.fn(),
+}))
+
+jest.mock('../processImage', () => ({
+  processImage: jest.fn(),
+}))
+
+jest.spyOn(Alert, 'alert')
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 }, mutations: { retry: 0 } } })
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children)
+}
+
+describe('useProcessImages', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns success results for all images', async () => {
+    const { getAllEmbeddings } = require('@/shared/db')
+    const { processImage } = require('../processImage')
+
+    getAllEmbeddings.mockResolvedValue([])
+    processImage
+      .mockResolvedValueOnce('file://result1.jpg')
+      .mockResolvedValueOnce('file://result2.jpg')
+
+    const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
+    act(() => { result.current.mutate(['file://a.jpg', 'file://b.jpg']) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual([
+      { status: 'success', originalUri: 'file://a.jpg', resultUri: 'file://result1.jpg' },
+      { status: 'success', originalUri: 'file://b.jpg', resultUri: 'file://result2.jpg' },
+    ])
+  })
+
+  it('continues processing remaining images when one fails', async () => {
+    const { getAllEmbeddings } = require('@/shared/db')
+    const { processImage } = require('../processImage')
+
+    getAllEmbeddings.mockResolvedValue([])
+    processImage
+      .mockRejectedValueOnce(new Error('native error'))
+      .mockResolvedValueOnce('file://result2.jpg')
+
+    const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
+    act(() => { result.current.mutate(['file://a.jpg', 'file://b.jpg']) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual([
+      { status: 'error', originalUri: 'file://a.jpg', resultUri: 'file://a.jpg', error: 'native error' },
+      { status: 'success', originalUri: 'file://b.jpg', resultUri: 'file://result2.jpg' },
+    ])
+  })
+
+  it('enters error state and shows Alert when getAllEmbeddings fails', async () => {
+    const { getAllEmbeddings } = require('@/shared/db')
+    getAllEmbeddings.mockRejectedValue(new Error('db error'))
+
+    const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
+    act(() => { result.current.mutate(['file://a.jpg']) })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(Alert.alert).toHaveBeenCalledWith('処理エラー', 'db error')
+  })
+
+  it('calls getAllEmbeddings only once for a batch of images', async () => {
+    const { getAllEmbeddings } = require('@/shared/db')
+    const { processImage } = require('../processImage')
+
+    getAllEmbeddings.mockResolvedValue([])
+    processImage.mockResolvedValue('file://result.jpg')
+
+    const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
+    act(() => { result.current.mutate(['file://a.jpg', 'file://b.jpg', 'file://c.jpg']) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(getAllEmbeddings).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns empty results immediately without calling getAllEmbeddings for empty input', async () => {
+    const { getAllEmbeddings } = require('@/shared/db')
+
+    const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
+    act(() => { result.current.mutate([]) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual([])
+    expect(getAllEmbeddings).not.toHaveBeenCalled()
+  })
+
+  it('tracks progress to total by end of batch', async () => {
+    const { getAllEmbeddings } = require('@/shared/db')
+    const { processImage } = require('../processImage')
+
+    getAllEmbeddings.mockResolvedValue([])
+    processImage.mockResolvedValue('file://result.jpg')
+
+    const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
+    act(() => { result.current.mutate(['file://a.jpg', 'file://b.jpg']) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.progress).toEqual({ current: 2, total: 2 })
+  })
+
+  it('stores error message as string even for non-Error throws', async () => {
+    const { getAllEmbeddings } = require('@/shared/db')
+    const { processImage } = require('../processImage')
+
+    getAllEmbeddings.mockResolvedValue([])
+    // NativeModules が Error インスタンスでなく文字列を throw する場合
+    processImage.mockRejectedValueOnce('native bridge exception string')
+
+    const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
+    act(() => { result.current.mutate(['file://a.jpg']) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const item = result.current.data![0]
+    expect(item.status).toBe('error')
+    if (item.status === 'error') {
+      expect(typeof item.error).toBe('string')
+      expect(item.error).not.toBe('undefined')
+    }
+  })
+})

--- a/src/features/image-processing/model/__tests__/useProcessImages.test.ts
+++ b/src/features/image-processing/model/__tests__/useProcessImages.test.ts
@@ -12,8 +12,6 @@ jest.mock('../processImage', () => ({
   processImage: jest.fn(),
 }))
 
-jest.spyOn(Alert, 'alert')
-
 function makeWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 }, mutations: { retry: 0 } } })
   return ({ children }: { children: React.ReactNode }) =>
@@ -21,7 +19,10 @@ function makeWrapper() {
 }
 
 describe('useProcessImages', () => {
-  beforeEach(() => jest.clearAllMocks())
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(Alert, 'alert')
+  })
 
   it('returns success results for all images', async () => {
     const { getAllEmbeddings } = require('@/shared/db')
@@ -42,7 +43,7 @@ describe('useProcessImages', () => {
     ])
   })
 
-  it('continues processing remaining images when one fails', async () => {
+  it('continues processing remaining images when one fails, without showing Alert', async () => {
     const { getAllEmbeddings } = require('@/shared/db')
     const { processImage } = require('../processImage')
 
@@ -59,6 +60,8 @@ describe('useProcessImages', () => {
       { status: 'error', originalUri: 'file://a.jpg', resultUri: 'file://a.jpg', error: 'native error' },
       { status: 'success', originalUri: 'file://b.jpg', resultUri: 'file://result2.jpg' },
     ])
+    // 画像単位のエラーは onError (Alert) を発火しない。結果オブジェクトで通知する
+    expect(Alert.alert).not.toHaveBeenCalled()
   })
 
   it('enters error state and shows Alert when getAllEmbeddings fails', async () => {
@@ -126,8 +129,7 @@ describe('useProcessImages', () => {
     const item = result.current.data![0]
     expect(item.status).toBe('error')
     if (item.status === 'error') {
-      expect(typeof item.error).toBe('string')
-      expect(item.error).not.toBe('undefined')
+      expect(item.error).toBe('native bridge exception string')
     }
   })
 })

--- a/src/features/image-processing/model/__tests__/useProcessImages.test.ts
+++ b/src/features/image-processing/model/__tests__/useProcessImages.test.ts
@@ -3,10 +3,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { Alert } from 'react-native'
 import { useProcessImages } from '../useProcessImages'
+import { insertPerson, insertEmbedding } from '@/shared/db'
+import * as dbModule from '@/shared/db'
 
-jest.mock('@/shared/db', () => ({
-  getAllEmbeddings: jest.fn(),
-}))
+jest.mock('@/shared/db', () => ({ __esModule: true, ...jest.requireActual('@/shared/db') }))
 
 jest.mock('../processImage', () => ({
   processImage: jest.fn(),
@@ -16,6 +16,20 @@ function makeWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 }, mutations: { retry: 0 } } })
   return ({ children }: { children: React.ReactNode }) =>
     React.createElement(QueryClientProvider, { client: qc }, children)
+}
+
+const NOW = '2026-01-01T00:00:00.000Z'
+
+async function seedEmbedding() {
+  await insertPerson({ id: 'p1', name: 'Test', memo: null, created_at: NOW, updated_at: NOW })
+  await insertEmbedding({
+    id: 'e1',
+    person_id: 'p1',
+    embedding: JSON.stringify(Array(128).fill(0.5)),
+    source_uri: 'u',
+    created_at: NOW,
+    updated_at: NOW,
+  })
 }
 
 describe('useProcessImages', () => {
@@ -29,10 +43,7 @@ describe('useProcessImages', () => {
   })
 
   it('returns success results for all images', async () => {
-    const { getAllEmbeddings } = require('@/shared/db')
     const { processImage } = require('../processImage')
-
-    getAllEmbeddings.mockResolvedValue([])
     processImage
       .mockResolvedValueOnce('file://result1.jpg')
       .mockResolvedValueOnce('file://result2.jpg')
@@ -48,10 +59,7 @@ describe('useProcessImages', () => {
   })
 
   it('continues processing remaining images when one fails, without showing Alert', async () => {
-    const { getAllEmbeddings } = require('@/shared/db')
     const { processImage } = require('../processImage')
-
-    getAllEmbeddings.mockResolvedValue([])
     processImage
       .mockRejectedValueOnce(new Error('native error'))
       .mockResolvedValueOnce('file://result2.jpg')
@@ -69,8 +77,7 @@ describe('useProcessImages', () => {
   })
 
   it('enters error state and shows Alert when getAllEmbeddings fails', async () => {
-    const { getAllEmbeddings } = require('@/shared/db')
-    getAllEmbeddings.mockRejectedValue(new Error('db error'))
+    jest.spyOn(dbModule, 'getAllEmbeddings').mockRejectedValueOnce(new Error('db error'))
 
     const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
     act(() => { result.current.mutate(['file://a.jpg']) })
@@ -80,53 +87,50 @@ describe('useProcessImages', () => {
   })
 
   it('passes preloaded embeddings to processImage for each image in the batch', async () => {
-    const { getAllEmbeddings } = require('@/shared/db')
+    await seedEmbedding()
     const { processImage } = require('../processImage')
-
-    const storedEmbeddings = [
-      { id: '1', person_id: 'p1', embedding: JSON.stringify(Array(128).fill(0.5)), source_uri: 'u', created_at: '', updated_at: '' },
-    ]
-    getAllEmbeddings.mockResolvedValue(storedEmbeddings)
     processImage.mockResolvedValue('file://result.jpg')
 
     const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
     act(() => { result.current.mutate(['file://a.jpg', 'file://b.jpg']) })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(processImage).toHaveBeenCalledWith('file://a.jpg', storedEmbeddings)
-    expect(processImage).toHaveBeenCalledWith('file://b.jpg', storedEmbeddings)
+    // DB から取得した embeddings が processImage の第2引数として渡されていることを確認
+    expect(processImage).toHaveBeenCalledWith(
+      'file://a.jpg',
+      expect.arrayContaining([expect.objectContaining({ id: 'e1', person_id: 'p1' })])
+    )
+    expect(processImage).toHaveBeenCalledWith(
+      'file://b.jpg',
+      expect.arrayContaining([expect.objectContaining({ id: 'e1', person_id: 'p1' })])
+    )
   })
 
   it('calls getAllEmbeddings only once for a batch of images', async () => {
-    const { getAllEmbeddings } = require('@/shared/db')
+    const getAllEmbeddingsSpy = jest.spyOn(dbModule, 'getAllEmbeddings')
     const { processImage } = require('../processImage')
-
-    getAllEmbeddings.mockResolvedValue([])
     processImage.mockResolvedValue('file://result.jpg')
 
     const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
     act(() => { result.current.mutate(['file://a.jpg', 'file://b.jpg', 'file://c.jpg']) })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(getAllEmbeddings).toHaveBeenCalledTimes(1)
+    expect(getAllEmbeddingsSpy).toHaveBeenCalledTimes(1)
   })
 
   it('returns empty results immediately without calling getAllEmbeddings for empty input', async () => {
-    const { getAllEmbeddings } = require('@/shared/db')
+    const getAllEmbeddingsSpy = jest.spyOn(dbModule, 'getAllEmbeddings')
 
     const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
     act(() => { result.current.mutate([]) })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data).toEqual([])
-    expect(getAllEmbeddings).not.toHaveBeenCalled()
+    expect(getAllEmbeddingsSpy).not.toHaveBeenCalled()
   })
 
   it('tracks progress to total by end of batch', async () => {
-    const { getAllEmbeddings } = require('@/shared/db')
     const { processImage } = require('../processImage')
-
-    getAllEmbeddings.mockResolvedValue([])
     processImage.mockResolvedValue('file://result.jpg')
 
     const { result } = renderHook(() => useProcessImages(), { wrapper: makeWrapper() })
@@ -137,10 +141,7 @@ describe('useProcessImages', () => {
   })
 
   it('resolves as success (not error) even when all images fail', async () => {
-    const { getAllEmbeddings } = require('@/shared/db')
     const { processImage } = require('../processImage')
-
-    getAllEmbeddings.mockResolvedValue([])
     processImage
       .mockRejectedValueOnce(new Error('fail1'))
       .mockRejectedValueOnce(new Error('fail2'))
@@ -159,10 +160,7 @@ describe('useProcessImages', () => {
   })
 
   it('stores error message as string even for non-Error throws', async () => {
-    const { getAllEmbeddings } = require('@/shared/db')
     const { processImage } = require('../processImage')
-
-    getAllEmbeddings.mockResolvedValue([])
     // NativeModules が Error インスタンスでなく文字列を throw する場合
     processImage.mockRejectedValueOnce('native bridge exception string')
 

--- a/src/features/image-processing/model/processImage.ts
+++ b/src/features/image-processing/model/processImage.ts
@@ -1,0 +1,46 @@
+import { FaceDetector, FaceNet, Mosaic } from '@/shared/native'
+import { getAllEmbeddings } from '@/shared/db'
+import type { Embedding } from '@/shared/db'
+import { cosineSimilarity, cropFace, resizeForMosaic } from '@/shared/lib'
+import { FACE_SIMILARITY_THRESHOLD } from '@/shared/config'
+
+export async function processImage(uri: string, preloadedEmbeddings?: Embedding[]): Promise<string> {
+  const boxes = await FaceDetector.detect(uri)
+  if (boxes.length === 0) return uri
+
+  const croppedUris = await Promise.all(boxes.map((box) => cropFace(uri, box)))
+  const faceEmbeddings = await FaceNet.extractAll(croppedUris)
+  const storedEmbeddings = preloadedEmbeddings ?? (await getAllEmbeddings())
+
+  // person_id ごとにグループ化して平均類似度で判定（1枚の偶然の一致を防ぐ）
+  const embeddingsByPerson = storedEmbeddings.reduce<Record<string, number[][]>>(
+    (acc, stored) => {
+      const vec: number[] = JSON.parse(stored.embedding)
+      ;(acc[stored.person_id] ??= []).push(vec)
+      return acc
+    },
+    {}
+  )
+
+  const regionsToBlur = boxes.filter((_, i) => {
+    const faceEmbedding = faceEmbeddings[i]
+    if (!faceEmbedding) return false
+
+    return Object.values(embeddingsByPerson).some((vecs) => {
+      const avgSim = vecs.reduce((sum, v) => sum + cosineSimilarity(faceEmbedding, v), 0) / vecs.length
+      return avgSim > FACE_SIMILARITY_THRESHOLD
+    })
+  })
+
+  if (regionsToBlur.length === 0) return uri
+
+  // Skia のデコード失敗を防ぐため ImageManipulator で正規化してから渡す
+  const { uri: resizedUri, scale } = await resizeForMosaic(uri)
+  const scaledRegions = regionsToBlur.map((box) => ({
+    x: box.x * scale,
+    y: box.y * scale,
+    width: box.width * scale,
+    height: box.height * scale,
+  }))
+  return Mosaic.apply(resizedUri, scaledRegions)
+}

--- a/src/features/image-processing/model/processImage.ts
+++ b/src/features/image-processing/model/processImage.ts
@@ -12,7 +12,7 @@ export async function processImage(uri: string, preloadedEmbeddings?: Embedding[
   const faceEmbeddings = await FaceNet.extractAll(croppedUris)
   const storedEmbeddings = preloadedEmbeddings ?? (await getAllEmbeddings())
 
-  // person_id ごとにグループ化して平均類似度で判定（1枚の偶然の一致を防ぐ）
+  // person_id ごとにグループ化し、いずれか1件でも閾値を超えれば一致とみなす（CLAUDE.md 照合方針）
   const embeddingsByPerson = storedEmbeddings.reduce<Record<string, number[][]>>(
     (acc, stored) => {
       const vec: number[] = JSON.parse(stored.embedding)
@@ -26,10 +26,9 @@ export async function processImage(uri: string, preloadedEmbeddings?: Embedding[
     const faceEmbedding = faceEmbeddings[i]
     if (!faceEmbedding) return false
 
-    return Object.values(embeddingsByPerson).some((vecs) => {
-      const avgSim = vecs.reduce((sum, v) => sum + cosineSimilarity(faceEmbedding, v), 0) / vecs.length
-      return avgSim > FACE_SIMILARITY_THRESHOLD
-    })
+    return Object.values(embeddingsByPerson).some((vecs) =>
+      vecs.some((v) => cosineSimilarity(faceEmbedding, v) > FACE_SIMILARITY_THRESHOLD)
+    )
   })
 
   if (regionsToBlur.length === 0) return uri

--- a/src/features/image-processing/model/processImage.ts
+++ b/src/features/image-processing/model/processImage.ts
@@ -10,34 +10,40 @@ export async function processImage(uri: string, preloadedEmbeddings?: Embedding[
 
   const croppedUris = await Promise.all(boxes.map((box) => cropFace(uri, box)))
   const faceEmbeddings = await FaceNet.extractAll(croppedUris)
+
+  if (faceEmbeddings.length !== boxes.length) {
+    throw new Error(
+      `[processImage] FaceNet embedding count mismatch: expected ${boxes.length}, got ${faceEmbeddings.length}`
+    )
+  }
+
   const storedEmbeddings = preloadedEmbeddings ?? (await getAllEmbeddings())
 
   // person_id ごとにグループ化し、いずれか1件でも閾値を超えれば一致とみなす（CLAUDE.md 照合方針）
   const embeddingsByPerson = storedEmbeddings.reduce<Record<string, number[][]>>(
     (acc, stored) => {
+      let vec: number[]
       try {
-        const vec: number[] = JSON.parse(stored.embedding)
-        ;(acc[stored.person_id] ??= []).push(vec)
+        vec = JSON.parse(stored.embedding)
       } catch (e) {
         console.error('[processImage] Corrupt embedding record skipped', {
           embeddingId: stored.id,
           personId: stored.person_id,
           error: e,
         })
+        return acc
       }
+      ;(acc[stored.person_id] ??= []).push(vec)
       return acc
     },
     {}
   )
 
-  const regionsToBlur = boxes.filter((_, i) => {
-    const faceEmbedding = faceEmbeddings[i]
-    if (!faceEmbedding) return false
-
-    return Object.values(embeddingsByPerson).some((vecs) =>
-      vecs.some((v) => cosineSimilarity(faceEmbedding, v) > FACE_SIMILARITY_THRESHOLD)
+  const regionsToBlur = boxes.filter((_, i) =>
+    Object.values(embeddingsByPerson).some((vecs) =>
+      vecs.some((v) => cosineSimilarity(faceEmbeddings[i], v) > FACE_SIMILARITY_THRESHOLD)
     )
-  })
+  )
 
   if (regionsToBlur.length === 0) return uri
 

--- a/src/features/image-processing/model/processImage.ts
+++ b/src/features/image-processing/model/processImage.ts
@@ -15,8 +15,16 @@ export async function processImage(uri: string, preloadedEmbeddings?: Embedding[
   // person_id ごとにグループ化し、いずれか1件でも閾値を超えれば一致とみなす（CLAUDE.md 照合方針）
   const embeddingsByPerson = storedEmbeddings.reduce<Record<string, number[][]>>(
     (acc, stored) => {
-      const vec: number[] = JSON.parse(stored.embedding)
-      ;(acc[stored.person_id] ??= []).push(vec)
+      try {
+        const vec: number[] = JSON.parse(stored.embedding)
+        ;(acc[stored.person_id] ??= []).push(vec)
+      } catch (e) {
+        console.error('[processImage] Corrupt embedding record skipped', {
+          embeddingId: stored.id,
+          personId: stored.person_id,
+          error: e,
+        })
+      }
       return acc
     },
     {}

--- a/src/features/image-processing/model/useProcessImage.ts
+++ b/src/features/image-processing/model/useProcessImage.ts
@@ -1,52 +1,10 @@
 import { useMutation } from '@tanstack/react-query'
 import { Alert } from 'react-native'
-import { FaceDetector, FaceNet, Mosaic } from '@/shared/native'
-import { getAllEmbeddings } from '@/shared/db'
-import { cosineSimilarity, cropFace, resizeForMosaic } from '@/shared/lib'
-import { FACE_SIMILARITY_THRESHOLD } from '@/shared/config'
+import { processImage } from './processImage'
 
 export function useProcessImage() {
   return useMutation({
-    mutationFn: async (uri: string): Promise<string> => {
-      const boxes = await FaceDetector.detect(uri)
-      if (boxes.length === 0) return uri
-
-      const croppedUris = await Promise.all(boxes.map((box) => cropFace(uri, box)))
-      const faceEmbeddings = await FaceNet.extractAll(croppedUris)
-      const storedEmbeddings = await getAllEmbeddings()
-
-      // person_id ごとにグループ化して平均類似度で判定（1枚の偶然の一致を防ぐ）
-      const embeddingsByPerson = storedEmbeddings.reduce<Record<string, number[][]>>(
-        (acc, stored) => {
-          const vec: number[] = JSON.parse(stored.embedding)
-          ;(acc[stored.person_id] ??= []).push(vec)
-          return acc
-        },
-        {}
-      )
-
-      const regionsToBlur = boxes.filter((_, i) => {
-        const faceEmbedding = faceEmbeddings[i]
-        if (!faceEmbedding) return false
-
-        return Object.values(embeddingsByPerson).some((vecs) => {
-          const avgSim = vecs.reduce((sum, v) => sum + cosineSimilarity(faceEmbedding, v), 0) / vecs.length
-          return avgSim > FACE_SIMILARITY_THRESHOLD
-        })
-      })
-
-      if (regionsToBlur.length === 0) return uri
-
-      // Skia のデコード失敗を防ぐため ImageManipulator で正規化してから渡す
-      const { uri: resizedUri, scale } = await resizeForMosaic(uri)
-      const scaledRegions = regionsToBlur.map((box) => ({
-        x: box.x * scale,
-        y: box.y * scale,
-        width: box.width * scale,
-        height: box.height * scale,
-      }))
-      return Mosaic.apply(resizedUri, scaledRegions)
-    },
+    mutationFn: (uri: string) => processImage(uri),
     onError: (error: Error) => {
       Alert.alert('処理エラー', error.message)
     },

--- a/src/features/image-processing/model/useProcessImage.ts
+++ b/src/features/image-processing/model/useProcessImage.ts
@@ -6,7 +6,9 @@ export function useProcessImage() {
   return useMutation({
     mutationFn: (uri: string) => processImage(uri),
     onError: (error: Error) => {
-      Alert.alert('処理エラー', error.message)
+      const message = error instanceof Error ? error.message : String(error)
+      console.error('[useProcessImage] processImage failed', { error })
+      Alert.alert('処理エラー', message)
     },
   })
 }

--- a/src/features/image-processing/model/useProcessImages.ts
+++ b/src/features/image-processing/model/useProcessImages.ts
@@ -54,7 +54,9 @@ export function useProcessImages() {
     onError: (error: Error) => {
       // 画像処理単位のエラーはループ内でキャッチし results に格納する。
       // ここに到達するのは getAllEmbeddings など前処理の失敗時のみ。
-      Alert.alert('処理エラー', error.message)
+      // ネイティブ層が非 Error を throw する場合も考慮して防御的に処理する
+      console.error('[useProcessImages] Pre-processing step failed', { error })
+      Alert.alert('処理エラー', 'データの読み込みに失敗しました。アプリを再起動してもう一度お試しください。')
     },
   })
 

--- a/src/features/image-processing/model/useProcessImages.ts
+++ b/src/features/image-processing/model/useProcessImages.ts
@@ -29,6 +29,9 @@ export function useProcessImages() {
 
       // バッチ処理全体で共通のEmbeddingを事前取得（N回のDB読み込みを1回に削減）
       const storedEmbeddings = await getAllEmbeddings()
+      if (storedEmbeddings.length === 0) {
+        console.warn('[useProcessImages] getAllEmbeddings returned empty — no face matching will occur')
+      }
 
       if (isMountedRef.current) setProgress({ current: 0, total: uris.length })
 
@@ -49,6 +52,8 @@ export function useProcessImages() {
       return results
     },
     onError: (error: Error) => {
+      // 画像処理単位のエラーはループ内でキャッチし results に格納する。
+      // ここに到達するのは getAllEmbeddings など前処理の失敗時のみ。
       Alert.alert('処理エラー', error.message)
     },
   })

--- a/src/features/image-processing/model/useProcessImages.ts
+++ b/src/features/image-processing/model/useProcessImages.ts
@@ -4,11 +4,9 @@ import { useMutation } from '@tanstack/react-query'
 import { getAllEmbeddings } from '@/shared/db'
 import { processImage } from './processImage'
 
-export type ImageProcessResult = {
-  originalUri: string
-  resultUri: string
-  error?: string
-}
+export type ImageProcessResult =
+  | { status: 'success'; originalUri: string; resultUri: string }
+  | { status: 'error'; originalUri: string; resultUri: string; error: string }
 
 export type ProcessProgress = {
   current: number
@@ -27,6 +25,8 @@ export function useProcessImages() {
 
   const mutation = useMutation({
     mutationFn: async (uris: string[]): Promise<ImageProcessResult[]> => {
+      if (uris.length === 0) return []
+
       // バッチ処理全体で共通のEmbeddingを事前取得（N回のDB読み込みを1回に削減）
       const storedEmbeddings = await getAllEmbeddings()
 
@@ -37,9 +37,11 @@ export function useProcessImages() {
         const uri = uris[i]
         try {
           const resultUri = await processImage(uri, storedEmbeddings)
-          results.push({ originalUri: uri, resultUri })
+          results.push({ status: 'success', originalUri: uri, resultUri })
         } catch (e) {
-          results.push({ originalUri: uri, resultUri: uri, error: (e as Error).message })
+          const message = e instanceof Error ? e.message : String(e)
+          console.error('[useProcessImages] Failed to process image', { uri, error: e })
+          results.push({ status: 'error', originalUri: uri, resultUri: uri, error: message })
         }
         if (isMountedRef.current) setProgress({ current: i + 1, total: uris.length })
       }

--- a/src/features/image-processing/model/useProcessImages.ts
+++ b/src/features/image-processing/model/useProcessImages.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react'
+import { Alert } from 'react-native'
+import { useMutation } from '@tanstack/react-query'
+import { getAllEmbeddings } from '@/shared/db'
+import { processImage } from './processImage'
+
+export type ImageProcessResult = {
+  originalUri: string
+  resultUri: string
+  error?: string
+}
+
+export type ProcessProgress = {
+  current: number
+  total: number
+}
+
+export function useProcessImages() {
+  const [progress, setProgress] = useState<ProcessProgress>({ current: 0, total: 0 })
+  const isMountedRef = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  const mutation = useMutation({
+    mutationFn: async (uris: string[]): Promise<ImageProcessResult[]> => {
+      // バッチ処理全体で共通のEmbeddingを事前取得（N回のDB読み込みを1回に削減）
+      const storedEmbeddings = await getAllEmbeddings()
+
+      if (isMountedRef.current) setProgress({ current: 0, total: uris.length })
+
+      const results: ImageProcessResult[] = []
+      for (let i = 0; i < uris.length; i++) {
+        const uri = uris[i]
+        try {
+          const resultUri = await processImage(uri, storedEmbeddings)
+          results.push({ originalUri: uri, resultUri })
+        } catch (e) {
+          results.push({ originalUri: uri, resultUri: uri, error: (e as Error).message })
+        }
+        if (isMountedRef.current) setProgress({ current: i + 1, total: uris.length })
+      }
+
+      return results
+    },
+    onError: (error: Error) => {
+      Alert.alert('処理エラー', error.message)
+    },
+  })
+
+  return { ...mutation, progress }
+}

--- a/src/features/image-processing/ui/ProcessBatchResultView.tsx
+++ b/src/features/image-processing/ui/ProcessBatchResultView.tsx
@@ -53,8 +53,8 @@ export function ProcessBatchResultView({ results, onSelectNew }: ProcessBatchRes
             <View style={styles.imageWrapper}>
               <Image source={{ uri: item.resultUri }} style={styles.image} resizeMode="cover" />
               {item.status === 'error' && (
-                <View style={styles.errorOverlay}>
-                  <Text style={styles.errorOverlayText}>処理失敗</Text>
+                <View style={styles.errorBadge}>
+                  <Text style={styles.errorBadgeText}>未処理</Text>
                 </View>
               )}
             </View>
@@ -65,10 +65,12 @@ export function ProcessBatchResultView({ results, onSelectNew }: ProcessBatchRes
                   <Text style={styles.shareText}>共有</Text>
                 </TouchableOpacity>
               )}
-              {item.status === 'error' && (
-                <Text style={styles.errorDetailText} numberOfLines={1}>処理に失敗しました</Text>
-              )}
             </View>
+            {item.status === 'error' && (
+              <View style={styles.errorMessageRow}>
+                <Text style={styles.errorMessageText} numberOfLines={2}>{item.error}</Text>
+              </View>
+            )}
           </View>
         )}
       />
@@ -98,13 +100,16 @@ const styles = StyleSheet.create({
   },
   imageWrapper: { aspectRatio: 4 / 3, position: 'relative' },
   image: { width: '100%', height: '100%' },
-  errorOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.6)',
-    alignItems: 'center',
-    justifyContent: 'center',
+  errorBadge: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    backgroundColor: '#FF3B30',
+    borderRadius: 6,
+    paddingVertical: 2,
+    paddingHorizontal: 8,
   },
-  errorOverlayText: { color: '#FF3B30', fontSize: 16, fontWeight: '700' },
+  errorBadgeText: { color: '#fff', fontSize: 11, fontWeight: '700' },
   cardFooter: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -113,7 +118,11 @@ const styles = StyleSheet.create({
   },
   imageLabel: { color: '#8E8E93', fontSize: 13 },
   shareText: { color: '#007AFF', fontSize: 15, fontWeight: '600' },
-  errorDetailText: { color: '#FF3B30', fontSize: 11, flex: 1, marginLeft: 8, textAlign: 'right' },
+  errorMessageRow: {
+    paddingHorizontal: 12,
+    paddingBottom: 12,
+  },
+  errorMessageText: { color: '#FF3B30', fontSize: 12 },
   actions: { padding: 20 },
   button: {
     backgroundColor: '#007AFF',

--- a/src/features/image-processing/ui/ProcessBatchResultView.tsx
+++ b/src/features/image-processing/ui/ProcessBatchResultView.tsx
@@ -58,6 +58,9 @@ export function ProcessBatchResultView({ results, onSelectNew }: ProcessBatchRes
                   <Text style={styles.shareText}>共有</Text>
                 </TouchableOpacity>
               )}
+              {item.status === 'error' && (
+                <Text style={styles.errorDetailText} numberOfLines={1}>{item.error}</Text>
+              )}
             </View>
           </View>
         )}
@@ -103,6 +106,7 @@ const styles = StyleSheet.create({
   },
   imageLabel: { color: '#8E8E93', fontSize: 13 },
   shareText: { color: '#007AFF', fontSize: 15, fontWeight: '600' },
+  errorDetailText: { color: '#FF3B30', fontSize: 11, flex: 1, marginLeft: 8, textAlign: 'right' },
   actions: { padding: 20 },
   button: {
     backgroundColor: '#007AFF',

--- a/src/features/image-processing/ui/ProcessBatchResultView.tsx
+++ b/src/features/image-processing/ui/ProcessBatchResultView.tsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import {
+  View,
+  Text,
+  Image,
+  StyleSheet,
+  FlatList,
+  Share,
+  TouchableOpacity,
+} from 'react-native'
+import type { ImageProcessResult } from '../model/useProcessImages'
+
+interface ProcessBatchResultViewProps {
+  results: ImageProcessResult[]
+  onSelectNew: () => void
+}
+
+export function ProcessBatchResultView({ results, onSelectNew }: ProcessBatchResultViewProps) {
+  const errorCount = results.filter((r) => r.error).length
+
+  const handleShare = async (uri: string) => {
+    try {
+      await Share.share({ url: uri })
+    } catch {
+      // share cancelled
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      {errorCount > 0 && (
+        <View style={styles.errorBanner}>
+          <Text style={styles.errorBannerText}>{errorCount}枚の処理に失敗しました</Text>
+        </View>
+      )}
+
+      <FlatList
+        data={results}
+        keyExtractor={(item) => item.originalUri}
+        contentContainerStyle={styles.listContent}
+        renderItem={({ item, index }) => (
+          <View style={styles.resultCard}>
+            <View style={styles.imageWrapper}>
+              <Image source={{ uri: item.resultUri }} style={styles.image} resizeMode="cover" />
+              {item.error && (
+                <View style={styles.errorOverlay}>
+                  <Text style={styles.errorOverlayText}>処理失敗</Text>
+                </View>
+              )}
+            </View>
+            <View style={styles.cardFooter}>
+              <Text style={styles.imageLabel}>{index + 1}枚目</Text>
+              {!item.error && (
+                <TouchableOpacity onPress={() => handleShare(item.resultUri)}>
+                  <Text style={styles.shareText}>共有</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          </View>
+        )}
+      />
+
+      <View style={styles.actions}>
+        <TouchableOpacity style={styles.button} onPress={onSelectNew}>
+          <Text style={styles.buttonText}>別の画像を選択</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#000' },
+  errorBanner: {
+    backgroundColor: '#FF3B30',
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
+  errorBannerText: { color: '#fff', fontSize: 14, fontWeight: '600', textAlign: 'center' },
+  listContent: { padding: 16, gap: 16 },
+  resultCard: {
+    backgroundColor: '#1c1c1e',
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  imageWrapper: { aspectRatio: 4 / 3, position: 'relative' },
+  image: { width: '100%', height: '100%' },
+  errorOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  errorOverlayText: { color: '#FF3B30', fontSize: 16, fontWeight: '700' },
+  cardFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 12,
+  },
+  imageLabel: { color: '#8E8E93', fontSize: 13 },
+  shareText: { color: '#007AFF', fontSize: 15, fontWeight: '600' },
+  actions: { padding: 20 },
+  button: {
+    backgroundColor: '#007AFF',
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  buttonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+})

--- a/src/features/image-processing/ui/ProcessBatchResultView.tsx
+++ b/src/features/image-processing/ui/ProcessBatchResultView.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   FlatList,
   Share,
+  Alert,
   TouchableOpacity,
 } from 'react-native'
 import type { ImageProcessResult } from '../model/useProcessImages'
@@ -16,13 +17,15 @@ interface ProcessBatchResultViewProps {
 }
 
 export function ProcessBatchResultView({ results, onSelectNew }: ProcessBatchResultViewProps) {
-  const errorCount = results.filter((r) => r.error).length
+  const errorCount = results.filter((r) => r.status === 'error').length
 
   const handleShare = async (uri: string) => {
     try {
       await Share.share({ url: uri })
-    } catch {
-      // share cancelled
+    } catch (e) {
+      // Share.share は iOS でキャンセル時に reject しない。ここに来るのは実際のエラー
+      console.error('[ProcessBatchResultView] Share failed', { uri, error: e })
+      Alert.alert('共有エラー', '画像を共有できませんでした')
     }
   }
 
@@ -42,7 +45,7 @@ export function ProcessBatchResultView({ results, onSelectNew }: ProcessBatchRes
           <View style={styles.resultCard}>
             <View style={styles.imageWrapper}>
               <Image source={{ uri: item.resultUri }} style={styles.image} resizeMode="cover" />
-              {item.error && (
+              {item.status === 'error' && (
                 <View style={styles.errorOverlay}>
                   <Text style={styles.errorOverlayText}>処理失敗</Text>
                 </View>
@@ -50,7 +53,7 @@ export function ProcessBatchResultView({ results, onSelectNew }: ProcessBatchRes
             </View>
             <View style={styles.cardFooter}>
               <Text style={styles.imageLabel}>{index + 1}枚目</Text>
-              {!item.error && (
+              {item.status === 'success' && (
                 <TouchableOpacity onPress={() => handleShare(item.resultUri)}>
                   <Text style={styles.shareText}>共有</Text>
                 </TouchableOpacity>

--- a/src/features/image-processing/ui/ProcessBatchResultView.tsx
+++ b/src/features/image-processing/ui/ProcessBatchResultView.tsx
@@ -21,9 +21,16 @@ export function ProcessBatchResultView({ results, onSelectNew }: ProcessBatchRes
 
   const handleShare = async (uri: string) => {
     try {
-      await Share.share({ url: uri })
+      const result = await Share.share({ url: uri })
+      if (result.action === 'dismissedAction') return
     } catch (e) {
-      // Share.share は iOS でキャンセル時に reject しない。ここに来るのは実際のエラー
+      // iOS ではキャンセル時に reject しない。
+      // Android ではキャンセル時に reject することがあるため、キャンセルと実際のエラーを区別する。
+      const message = e instanceof Error ? e.message : String(e)
+      if (message.toLowerCase().includes('cancel')) {
+        console.warn('[ProcessBatchResultView] Share dismissed via exception (Android)', { uri, error: e })
+        return
+      }
       console.error('[ProcessBatchResultView] Share failed', { uri, error: e })
       Alert.alert('共有エラー', '画像を共有できませんでした')
     }
@@ -59,7 +66,7 @@ export function ProcessBatchResultView({ results, onSelectNew }: ProcessBatchRes
                 </TouchableOpacity>
               )}
               {item.status === 'error' && (
-                <Text style={styles.errorDetailText} numberOfLines={1}>{item.error}</Text>
+                <Text style={styles.errorDetailText} numberOfLines={1}>処理に失敗しました</Text>
               )}
             </View>
           </View>

--- a/src/features/person-management/model/__tests__/useDeletePerson.test.ts
+++ b/src/features/person-management/model/__tests__/useDeletePerson.test.ts
@@ -2,10 +2,10 @@ import { renderHook, act, waitFor } from '@testing-library/react-native'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { useDeletePerson } from '../useDeletePerson'
+import { insertPerson, getAllPersons } from '@/shared/db'
+import * as dbModule from '@/shared/db'
 
-jest.mock('@/shared/db', () => ({
-  deletePerson: jest.fn(),
-}))
+jest.mock('@/shared/db', () => ({ __esModule: true, ...jest.requireActual('@/shared/db') }))
 
 function makeWrapper(qc: QueryClient) {
   return ({ children }: { children: React.ReactNode }) =>
@@ -16,12 +16,13 @@ function makeQc() {
   return new QueryClient({ defaultOptions: { queries: { retry: 0 }, mutations: { retry: 0 } } })
 }
 
+const NOW = '2026-01-01T00:00:00.000Z'
+
 describe('useDeletePerson', () => {
-  beforeEach(() => { jest.clearAllMocks() })
+  afterEach(() => jest.restoreAllMocks())
 
   it('calls deletePerson with correct id', async () => {
-    const { deletePerson } = require('@/shared/db')
-    deletePerson.mockResolvedValue(undefined)
+    await insertPerson({ id: 'person-id-1', name: 'Test', memo: null, created_at: NOW, updated_at: NOW })
 
     const qc = makeQc()
     const { result } = renderHook(() => useDeletePerson(), { wrapper: makeWrapper(qc) })
@@ -29,12 +30,12 @@ describe('useDeletePerson', () => {
     act(() => { result.current.mutate('person-id-1') })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(deletePerson).toHaveBeenCalledWith('person-id-1')
+    const persons = await getAllPersons()
+    expect(persons).toHaveLength(0)
   })
 
   it('invalidates persons query on success', async () => {
-    const { deletePerson } = require('@/shared/db')
-    deletePerson.mockResolvedValue(undefined)
+    await insertPerson({ id: 'person-id-1', name: 'Test', memo: null, created_at: NOW, updated_at: NOW })
 
     const qc = makeQc()
     const invalidateSpy = jest.spyOn(qc, 'invalidateQueries')
@@ -47,8 +48,7 @@ describe('useDeletePerson', () => {
   })
 
   it('enters error state when deletePerson fails', async () => {
-    const { deletePerson } = require('@/shared/db')
-    deletePerson.mockRejectedValue(new Error('db error'))
+    jest.spyOn(dbModule, 'deletePerson').mockRejectedValueOnce(new Error('db error'))
 
     const qc = makeQc()
     const { result } = renderHook(() => useDeletePerson(), { wrapper: makeWrapper(qc) })

--- a/src/features/person-management/model/__tests__/usePersons.test.ts
+++ b/src/features/person-management/model/__tests__/usePersons.test.ts
@@ -2,10 +2,11 @@ import { renderHook, waitFor } from '@testing-library/react-native'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { usePersons } from '../usePersons'
+import { insertPerson } from '@/shared/db'
+import * as dbModule from '@/shared/db'
+import type { Person } from '@/shared/db'
 
-jest.mock('@/shared/db', () => ({
-  getAllPersons: jest.fn(),
-}))
+jest.mock('@/shared/db', () => ({ __esModule: true, ...jest.requireActual('@/shared/db') }))
 
 function makeWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } })
@@ -13,33 +14,31 @@ function makeWrapper() {
     React.createElement(QueryClientProvider, { client: qc }, children)
 }
 
+const NOW = '2026-01-01T00:00:00.000Z'
+
+function makePerson(overrides: Partial<Person> = {}): Person {
+  return { id: '1', name: 'Alice', memo: null, created_at: NOW, updated_at: NOW, ...overrides }
+}
+
 describe('usePersons', () => {
-  beforeEach(() => { jest.clearAllMocks() })
+  afterEach(() => jest.restoreAllMocks())
 
   it('returns persons from db', async () => {
-    const { getAllPersons } = require('@/shared/db')
-    const mockPersons = [
-      { id: '1', name: 'Alice', memo: null, created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-01T00:00:00.000Z' },
-    ]
-    getAllPersons.mockResolvedValue(mockPersons)
+    await insertPerson(makePerson())
 
     const { result } = renderHook(() => usePersons(), { wrapper: makeWrapper() })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data).toEqual(mockPersons)
+    expect(result.current.data).toEqual([makePerson()])
   })
 
   it('returns empty array when no persons registered', async () => {
-    const { getAllPersons } = require('@/shared/db')
-    getAllPersons.mockResolvedValue([])
-
     const { result } = renderHook(() => usePersons(), { wrapper: makeWrapper() })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data).toEqual([])
   })
 
   it('enters error state when getAllPersons fails', async () => {
-    const { getAllPersons } = require('@/shared/db')
-    getAllPersons.mockRejectedValue(new Error('db error'))
+    jest.spyOn(dbModule, 'getAllPersons').mockRejectedValueOnce(new Error('db error'))
 
     const { result } = renderHook(() => usePersons(), { wrapper: makeWrapper() })
     await waitFor(() => expect(result.current.isError).toBe(true))

--- a/src/features/person-registration/model/__tests__/useRegisterPerson.test.ts
+++ b/src/features/person-registration/model/__tests__/useRegisterPerson.test.ts
@@ -2,6 +2,10 @@ import { renderHook, act, waitFor } from '@testing-library/react-native'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { useRegisterPerson } from '../useRegisterPerson'
+import { getAllPersons, getEmbeddingsByPersonId } from '@/shared/db'
+import * as dbModule from '@/shared/db'
+
+jest.mock('@/shared/db', () => ({ __esModule: true, ...jest.requireActual('@/shared/db') }))
 
 jest.mock('@/shared/native', () => ({
   FaceDetector: { detect: jest.fn() },
@@ -10,12 +14,6 @@ jest.mock('@/shared/native', () => ({
 
 jest.mock('@/shared/lib', () => ({
   cropFace: jest.fn(),
-}))
-
-jest.mock('@/shared/db', () => ({
-  withTransaction: jest.fn((fn: (db: unknown) => Promise<unknown>) => fn({})),
-  insertPerson: jest.fn(),
-  insertEmbedding: jest.fn(),
 }))
 
 function makeWrapper(qc: QueryClient) {
@@ -38,14 +36,12 @@ describe('useRegisterPerson', () => {
     FaceNet.extractAll.mockResolvedValue(EMBEDDINGS)
     const { cropFace } = require('@/shared/lib')
     cropFace.mockImplementation((_uri: string) => Promise.resolve('file://cropped.jpg'))
-    const { insertPerson, insertEmbedding } = require('@/shared/db')
-    insertPerson.mockResolvedValue(undefined)
-    insertEmbedding.mockResolvedValue(undefined)
   })
+
+  afterEach(() => jest.restoreAllMocks())
 
   it('calls FaceNet.extractAll before insertPerson (no orphaned records on FaceNet failure)', async () => {
     const { FaceNet } = require('@/shared/native')
-    const { insertPerson, insertEmbedding } = require('@/shared/db')
     FaceNet.extractAll.mockRejectedValueOnce(new Error('inference error'))
 
     const qc = makeQc()
@@ -53,24 +49,24 @@ describe('useRegisterPerson', () => {
     act(() => { result.current.mutate(INPUT) })
 
     await waitFor(() => expect(result.current.isError).toBe(true))
-    expect(insertPerson).not.toHaveBeenCalled()
-    expect(insertEmbedding).not.toHaveBeenCalled()
+    const persons = await getAllPersons()
+    expect(persons).toHaveLength(0)
   })
 
   it('calls insertPerson once and insertEmbedding per photo on success', async () => {
-    const { insertPerson, insertEmbedding } = require('@/shared/db')
     const qc = makeQc()
     const { result } = renderHook(() => useRegisterPerson(), { wrapper: makeWrapper(qc) })
 
     act(() => { result.current.mutate(INPUT) })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(insertPerson).toHaveBeenCalledTimes(1)
-    expect(insertEmbedding).toHaveBeenCalledTimes(3)
+    const persons = await getAllPersons()
+    expect(persons).toHaveLength(1)
+    const embeddings = await getEmbeddingsByPersonId(persons[0].id)
+    expect(embeddings).toHaveLength(3)
   })
 
   it('passes serialized embeddings and matching photoUris to insertEmbedding', async () => {
-    const { insertPerson, insertEmbedding } = require('@/shared/db')
     const qc = makeQc()
     const { result } = renderHook(() => useRegisterPerson(), { wrapper: makeWrapper(qc) })
 
@@ -78,9 +74,12 @@ describe('useRegisterPerson', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-    const personId = insertPerson.mock.calls[0][0].id
+    const persons = await getAllPersons()
+    const personId = persons[0].id
+    const embeddings = await getEmbeddingsByPersonId(personId)
+
     for (let i = 0; i < 3; i++) {
-      expect(insertEmbedding).toHaveBeenCalledWith(
+      expect(embeddings).toContainEqual(
         expect.objectContaining({
           person_id: personId,
           embedding: JSON.stringify(EMBEDDINGS[i]),
@@ -102,8 +101,7 @@ describe('useRegisterPerson', () => {
   })
 
   it('enters error state when insertPerson fails (after FaceNet succeeds)', async () => {
-    const { insertPerson } = require('@/shared/db')
-    insertPerson.mockRejectedValueOnce(new Error('db error'))
+    jest.spyOn(dbModule, 'insertPerson').mockRejectedValueOnce(new Error('db error'))
 
     const qc = makeQc()
     const { result } = renderHook(() => useRegisterPerson(), { wrapper: makeWrapper(qc) })

--- a/src/features/person-registration/ui/RegisterFaceSheet.tsx
+++ b/src/features/person-registration/ui/RegisterFaceSheet.tsx
@@ -42,14 +42,18 @@ export function RegisterFaceSheet({ visible, onClose }: RegisterFaceSheetProps) 
   }, [reset, onClose])
 
   const handleAddPhoto = useCallback(async () => {
+    const remaining = FACE_REGISTER_MAX_PHOTOS - photos.length
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       quality: 1,
+      allowsMultipleSelection: true,
+      selectionLimit: remaining,
     })
     if (!result.canceled && result.assets.length > 0) {
-      setPhotos((prev) => [...prev, result.assets[0].uri].slice(0, FACE_REGISTER_MAX_PHOTOS))
+      const newUris = result.assets.map((a) => a.uri)
+      setPhotos((prev) => [...prev, ...newUris].slice(0, FACE_REGISTER_MAX_PHOTOS))
     }
-  }, [])
+  }, [photos.length])
 
   const handleCamera = useCallback(async () => {
     try {

--- a/src/features/person-registration/ui/RegisterFaceSheet.tsx
+++ b/src/features/person-registration/ui/RegisterFaceSheet.tsx
@@ -42,16 +42,21 @@ export function RegisterFaceSheet({ visible, onClose }: RegisterFaceSheetProps) 
   }, [reset, onClose])
 
   const handleAddPhoto = useCallback(async () => {
-    const remaining = FACE_REGISTER_MAX_PHOTOS - photos.length
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
-      quality: 1,
-      allowsMultipleSelection: true,
-      selectionLimit: remaining,
-    })
-    if (!result.canceled && result.assets.length > 0) {
-      const newUris = result.assets.map((a) => a.uri)
-      setPhotos((prev) => [...prev, ...newUris].slice(0, FACE_REGISTER_MAX_PHOTOS))
+    try {
+      const remaining = FACE_REGISTER_MAX_PHOTOS - photos.length
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        quality: 1,
+        allowsMultipleSelection: true,
+        selectionLimit: remaining,
+      })
+      if (!result.canceled && result.assets.length > 0) {
+        const newUris = result.assets.map((a) => a.uri)
+        setPhotos((prev) => [...prev, ...newUris].slice(0, FACE_REGISTER_MAX_PHOTOS))
+      }
+    } catch (e: unknown) {
+      console.error('[RegisterFaceSheet] launchImageLibraryAsync failed', { error: e })
+      Alert.alert('ライブラリエラー', '写真を選択できませんでした。もう一度お試しください。')
     }
   }, [photos.length])
 
@@ -67,8 +72,8 @@ export function RegisterFaceSheet({ visible, onClose }: RegisterFaceSheetProps) 
         setPhotos((prev) => [...prev, result.assets[0].uri].slice(0, FACE_REGISTER_MAX_PHOTOS))
       }
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e)
-      Alert.alert('カメラエラー', msg)
+      console.error('[RegisterFaceSheet] launchCameraAsync failed', { error: e })
+      Alert.alert('カメラエラー', '写真を撮影できませんでした。もう一度お試しください。')
     }
   }, [])
 

--- a/src/features/person-registration/ui/RegisterFaceSheet.tsx
+++ b/src/features/person-registration/ui/RegisterFaceSheet.tsx
@@ -45,7 +45,7 @@ export function RegisterFaceSheet({ visible, onClose }: RegisterFaceSheetProps) 
     try {
       const remaining = FACE_REGISTER_MAX_PHOTOS - photos.length
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: 'images',
         quality: 1,
         allowsMultipleSelection: true,
         selectionLimit: remaining,

--- a/src/shared/lib/__tests__/imageUtils.test.ts
+++ b/src/shared/lib/__tests__/imageUtils.test.ts
@@ -56,6 +56,71 @@ describe('isFileUri', () => {
   })
 })
 
+describe('resizeForMosaic', () => {
+  beforeEach(() => {
+    const { Image } = require('react-native')
+    const { manipulateAsync } = require('expo-image-manipulator')
+    Image.getSize.mockImplementation((_uri: string, success: (w: number, h: number) => void) => success(320, 240))
+    manipulateAsync.mockResolvedValue({ uri: 'file://processed.jpg' })
+  })
+
+  it('returns scale=1 and no resize action when image is within MOSAIC_MAX_DIMENSION', async () => {
+    // 320x240 < 1920 → scale = 1, no resize
+    const { resizeForMosaic } = require('../imageUtils')
+    const { manipulateAsync } = require('expo-image-manipulator')
+
+    const result = await resizeForMosaic('file://original.jpg')
+
+    expect(result.scale).toBe(1)
+    expect(result.uri).toBe('file://processed.jpg')
+    // resize action は含まれない（空配列）
+    expect(manipulateAsync).toHaveBeenCalledWith(
+      'file://original.jpg',
+      [],
+      expect.objectContaining({ format: 'jpeg' })
+    )
+  })
+
+  it('returns scale<1 and resize action when image exceeds MOSAIC_MAX_DIMENSION', async () => {
+    const { Image } = require('react-native')
+    const { manipulateAsync } = require('expo-image-manipulator')
+    // 3840x2160 → maxDim=3840 → scale=1920/3840=0.5
+    Image.getSize.mockImplementation((_uri: string, success: (w: number, h: number) => void) => success(3840, 2160))
+
+    const { resizeForMosaic } = require('../imageUtils')
+    const result = await resizeForMosaic('file://large.jpg')
+
+    expect(result.scale).toBe(0.5)
+    expect(manipulateAsync).toHaveBeenCalledWith(
+      'file://large.jpg',
+      [{ resize: { width: 1920, height: 1080 } }],
+      expect.objectContaining({ format: 'jpeg' })
+    )
+  })
+
+  it('uses the longer side (width) to determine scale', async () => {
+    const { Image } = require('react-native')
+    // 2560x1440 → maxDim=2560 → scale=1920/2560=0.75
+    Image.getSize.mockImplementation((_uri: string, success: (w: number, h: number) => void) => success(2560, 1440))
+
+    const { resizeForMosaic } = require('../imageUtils')
+    const result = await resizeForMosaic('file://img.jpg')
+
+    expect(result.scale).toBeCloseTo(0.75)
+  })
+
+  it('uses the longer side (height) to determine scale for portrait images', async () => {
+    const { Image } = require('react-native')
+    // 1440x3840 → maxDim=3840 → scale=1920/3840=0.5
+    Image.getSize.mockImplementation((_uri: string, success: (w: number, h: number) => void) => success(1440, 3840))
+
+    const { resizeForMosaic } = require('../imageUtils')
+    const result = await resizeForMosaic('file://portrait.jpg')
+
+    expect(result.scale).toBe(0.5)
+  })
+})
+
 describe('cropFace', () => {
   // getSize mock: 320x240
 


### PR DESCRIPTION
## Summary

Closes #47

- フォトライブラリで最大20枚の複数画像選択を有効化（カメラ撮影は従来の1枚フローを維持）
- `processImage.ts` にコアロジックを分離し、単枚・バッチ両方のフックで再利用
- `useProcessImages` フックで URI リストを順次処理・進捗をリアルタイム表示
- `app/process/batch.tsx` バッチ処理画面を新規追加（"2 / 5 枚処理中..." 表示）
- `ProcessBatchResultView` で処理結果をカード形式一覧・個別共有ボタン付きで表示
- エラーが発生した画像はスキップし残りの処理を継続、結果カードに "処理失敗" 表示

## Technical Decisions

- `getAllEmbeddings` をバッチ処理ループの前に1回だけ呼び出し、N回のDB読み込みを排除
- `isMountedRef` で処理途中のアンマウント後に `setProgress` を呼ばないよう保護
- `urisParam` が `string[]` になるExpo Router の挙動に対しクラッシュガードを追加（try/catch + Array.isArray）
- `useMutation` に `onError` を追加し、バッチ全体失敗時に `Alert.alert` でユーザー通知（プロジェクト規約準拠）

## Test plan

- [ ] フォトライブラリから複数枚（2枚以上）選択し、バッチ処理画面に遷移することを確認
- [ ] 処理中に "N / M 枚処理中..." が正しく更新されることを確認
- [ ] 処理完了後に結果カードが表示され、個別の共有ボタンが動作することを確認
- [ ] カメラ撮影フロー（1枚）が従来どおり動作することを確認
- [ ] 1枚だけ選択した場合もバッチ画面が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)