### PR TITLE
fix: バッチ処理で1枚目・3枚目にモザイクがかからない不具合を修正

### DIFF
--- a/src/features/image-processing/model/useProcessImages.ts
+++ b/src/features/image-processing/model/useProcessImages.ts
@@ -33,10 +33,9 @@ export function useProcessImages() {
         console.warn('[useProcessImages] getAllEmbeddings returned empty — no face matching will occur')
       }
 
-      if (isMountedRef.current) setProgress({ current: 0, total: uris.length })
-
       const results: ImageProcessResult[] = []
       for (let i = 0; i < uris.length; i++) {
+        if (isMountedRef.current) setProgress({ current: i + 1, total: uris.length })
         const uri = uris[i]
         try {
           const resultUri = await processImage(uri, storedEmbeddings)
@@ -46,7 +45,6 @@ export function useProcessImages() {
           console.error('[useProcessImages] Failed to process image', { uri, error: e })
           results.push({ status: 'error', originalUri: uri, resultUri: uri, error: message })
         }
-        if (isMountedRef.current) setProgress({ current: i + 1, total: uris.length })
       }
 
       return results

--- a/src/shared/native/FaceNet.ts
+++ b/src/shared/native/FaceNet.ts
@@ -66,6 +66,11 @@ export const FaceNet = {
   },
 
   extractAll: async (uris: string[]): Promise<number[][]> => {
-    return Promise.all(uris.map((uri) => FaceNet.extractEmbedding(uri)))
+    // TFLite モデルは並列 run() をサポートしないため逐次実行する
+    const results: number[][] = []
+    for (const uri of uris) {
+      results.push(await FaceNet.extractEmbedding(uri))
+    }
+    return results
   },
 }


### PR DESCRIPTION
## 不具合の概要

複数画像をバッチ処理した際に、2枚目のみモザイクが適用され、1枚目・3枚目はモザイクなし・エラーバッジなし（status: success）のまま表示される不具合。

## 根本原因

`FaceNet.extractAll` が `Promise.all` で並列実行していたため、同一 TFLite モデルインスタンスに対して複数の `model.run()` が同時に呼び出されていた。TFLite モデルは並列推論をサポートしないため、embedding が破損・同一値化し、類似度計算が正常に機能しなかった。

この問題は2箇所に影響していた：
- **画像処理時**: 1枚の画像に複数顔が検出された場合、全顔の embedding が壊れてモザイク対象外になる
- **人物登録時**: 3枚同時に `extractAll` → 3件の embedding が全て同じ値で保存される

## 修正内容

### `src/shared/native/FaceNet.ts`
- `extractAll` を `Promise.all`（並列）から `for...of`（逐次）に変更
- TFLite モデルの制約に合わせて1件ずつ順次 embedding を抽出する

### `src/features/image-processing/model/useProcessImages.ts`
- 進捗カウンターの更新タイミングをループの末尾から先頭に移動
- 処理中に「0/n」と表示されていた表示バグを修正（正しくは「1/n」から始まる）

## テスト計画

- [ ] 複数画像（3枚以上）を選択してバッチ処理し、各画像に正しくモザイクがかかることを確認
- [ ] 人物を新規登録してから画像処理し、登録人物のみにモザイクがかかることを確認
- [ ] 進捗表示が「1/n」→「2/n」→…の順で正しく更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)