### PR TITLE
feat: 処理前に顔ごとの隠す/隠さない選択を可能にする

### DIFF
--- a/app/process/[imageId].tsx
+++ b/app/process/[imageId].tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useRef } from 'react'
+import React from 'react'
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native'
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
-import { useProcessImage, ProcessResultView } from '@/features/image-processing'
+import { useFaceSelection, FaceSelectionView, ProcessResultView } from '@/features/image-processing'
 import { LoadingOverlay } from '@/shared/ui'
 
 export default function ProcessScreen() {
@@ -9,45 +9,44 @@ export default function ProcessScreen() {
   const router = useRouter()
   const uri = decodeURIComponent(imageId ?? '')
 
-  const { mutate: processImage, isPending, data: resultUri, error, reset } = useProcessImage()
+  const { phase, candidates, resultUri, error, toggleFace, confirm } = useFaceSelection(uri)
 
-  // processImage は useMutation が返す関数でレンダーごとに参照が変わるため deps に含めない。
-  // hasStarted で二重実行を防ぐ（ナビゲーション状態復元時の再マウントを含む）。
-  const hasStarted = useRef(false)
-  useEffect(() => {
-    if (uri && !hasStarted.current) {
-      hasStarted.current = true
-      processImage(uri)
-    }
-  }, [uri]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const handleRetry = () => {
-    reset()
-    router.back()
-  }
+  const handleRetry = () => router.back()
 
   return (
     <View style={styles.container}>
       <Stack.Screen options={{ headerShown: true, title: '処理結果', headerBackTitle: '戻る' }} />
 
-      {isPending && <LoadingOverlay message="顔を検出しています..." />}
+      {phase === 'detecting' && <LoadingOverlay message="顔を検出しています..." />}
 
-      {error && (
-        <View style={styles.errorContainer}>
-          <Text style={styles.errorText}>画像の処理に失敗しました</Text>
-          <Text style={styles.errorDetail}>{error.message}</Text>
-          <TouchableOpacity style={styles.retryButton} onPress={handleRetry}>
-            <Text style={styles.retryText}>別の画像を選択</Text>
-          </TouchableOpacity>
-        </View>
+      {phase === 'selecting' && (
+        <FaceSelectionView
+          uri={uri}
+          candidates={candidates}
+          onToggle={toggleFace}
+          onConfirm={confirm}
+        />
       )}
 
-      {resultUri && (
+      {phase === 'processing' && <LoadingOverlay message="モザイクを適用しています..." />}
+
+      {phase === 'done' && resultUri && (
         <ProcessResultView
           originalUri={uri}
           resultUri={resultUri}
           onRetry={handleRetry}
         />
+      )}
+
+      {phase === 'error' && (
+        <View style={styles.errorContainer}>
+          <Text style={styles.errorText}>
+            {error?.message ?? '画像の処理に失敗しました'}
+          </Text>
+          <TouchableOpacity style={styles.retryButton} onPress={handleRetry}>
+            <Text style={styles.retryText}>別の画像を選択</Text>
+          </TouchableOpacity>
+        </View>
       )}
     </View>
   )
@@ -63,7 +62,6 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   errorText: { fontSize: 18, fontWeight: '600', color: '#FF3B30', textAlign: 'center' },
-  errorDetail: { fontSize: 13, color: '#aaa', textAlign: 'center' },
   retryButton: {
     marginTop: 16,
     backgroundColor: '#007AFF',

--- a/src/features/image-processing/index.ts
+++ b/src/features/image-processing/index.ts
@@ -1,5 +1,8 @@
 export { useProcessImage } from './model/useProcessImage'
 export { useProcessImages } from './model/useProcessImages'
 export type { ImageProcessResult, ProcessProgress } from './model/useProcessImages'
+export { useFaceSelection } from './model/useFaceSelection'
+export type { FaceCandidate } from './model/types'
 export { ProcessResultView } from './ui/ProcessResultView'
 export { ProcessBatchResultView } from './ui/ProcessBatchResultView'
+export { FaceSelectionView } from './ui/FaceSelectionView'

--- a/src/features/image-processing/model/__tests__/applyMosaicToSelected.test.ts
+++ b/src/features/image-processing/model/__tests__/applyMosaicToSelected.test.ts
@@ -1,0 +1,63 @@
+import { applyMosaicToSelected } from '../applyMosaicToSelected'
+import type { FaceCandidate } from '../types'
+
+const mockBox = { x: 0, y: 0, width: 50, height: 50 }
+
+jest.mock('@/shared/native', () => ({
+  Mosaic: { apply: jest.fn().mockResolvedValue('file://blurred.jpg') },
+}))
+
+jest.mock('@/shared/lib', () => ({
+  resizeForMosaic: jest.fn().mockResolvedValue({ uri: 'file://resized.jpg', scale: 1 }),
+}))
+
+function makeCandidate(isSelected: boolean): FaceCandidate {
+  return { box: mockBox, isMatched: isSelected, isSelected }
+}
+
+describe('applyMosaicToSelected', () => {
+  beforeEach(() => { jest.clearAllMocks() })
+
+  it('returns original uri when no candidates are selected', async () => {
+    const { Mosaic } = require('@/shared/native')
+    const result = await applyMosaicToSelected('file://original.jpg', [makeCandidate(false)])
+    expect(result).toBe('file://original.jpg')
+    expect(Mosaic.apply).not.toHaveBeenCalled()
+  })
+
+  it('returns original uri when candidates array is empty', async () => {
+    const { Mosaic } = require('@/shared/native')
+    const result = await applyMosaicToSelected('file://original.jpg', [])
+    expect(result).toBe('file://original.jpg')
+    expect(Mosaic.apply).not.toHaveBeenCalled()
+  })
+
+  it('applies mosaic to selected faces', async () => {
+    const { Mosaic } = require('@/shared/native')
+    const result = await applyMosaicToSelected('file://original.jpg', [makeCandidate(true)])
+    expect(Mosaic.apply).toHaveBeenCalledWith('file://resized.jpg', [mockBox])
+    expect(result).toBe('file://blurred.jpg')
+  })
+
+  it('applies mosaic only to selected faces when mixed', async () => {
+    const { Mosaic } = require('@/shared/native')
+    const selectedBox = { x: 0, y: 0, width: 50, height: 50 }
+    const unselectedBox = { x: 100, y: 0, width: 50, height: 50 }
+    await applyMosaicToSelected('file://original.jpg', [
+      { box: selectedBox, isMatched: true, isSelected: true },
+      { box: unselectedBox, isMatched: false, isSelected: false },
+    ])
+    expect(Mosaic.apply).toHaveBeenCalledWith('file://resized.jpg', [selectedBox])
+  })
+
+  it('scales box coordinates by resizeForMosaic scale factor', async () => {
+    const { Mosaic } = require('@/shared/native')
+    const { resizeForMosaic } = require('@/shared/lib')
+    resizeForMosaic.mockResolvedValueOnce({ uri: 'file://resized.jpg', scale: 0.5 })
+    const box = { x: 10, y: 20, width: 50, height: 60 }
+    await applyMosaicToSelected('file://original.jpg', [{ box, isMatched: true, isSelected: true }])
+    expect(Mosaic.apply).toHaveBeenCalledWith('file://resized.jpg', [
+      { x: 5, y: 10, width: 25, height: 30 },
+    ])
+  })
+})

--- a/src/features/image-processing/model/__tests__/detectAndClassify.test.ts
+++ b/src/features/image-processing/model/__tests__/detectAndClassify.test.ts
@@ -1,0 +1,111 @@
+import { detectAndClassify } from '../detectAndClassify'
+import { FACE_SIMILARITY_THRESHOLD as THRESHOLD } from '@/shared/config'
+
+const mockEmbedding = Array(128).fill(0.5)
+const mockBox = { x: 0, y: 0, width: 50, height: 50 }
+const NOW = '2026-01-01T00:00:00.000Z'
+
+jest.mock('@/shared/native', () => ({
+  FaceDetector: { detect: jest.fn() },
+  FaceNet: { extractAll: jest.fn() },
+}))
+
+jest.mock('@/shared/lib', () => ({
+  cosineSimilarity: jest.fn(),
+  cropFace: jest.fn().mockResolvedValue('file://cropped.jpg'),
+}))
+
+function makeStoredEmbedding(id: string, personId: string) {
+  return {
+    id,
+    person_id: personId,
+    embedding: JSON.stringify(mockEmbedding),
+    source_uri: 'u',
+    created_at: NOW,
+    updated_at: NOW,
+  }
+}
+
+describe('detectAndClassify', () => {
+  beforeEach(() => { jest.clearAllMocks() })
+
+  it('returns empty array when no faces detected', async () => {
+    const { FaceDetector, FaceNet } = require('@/shared/native')
+    FaceDetector.detect.mockResolvedValue([])
+
+    const result = await detectAndClassify('file://image.jpg', [])
+
+    expect(result).toEqual([])
+    expect(FaceNet.extractAll).not.toHaveBeenCalled()
+  })
+
+  it('returns candidate with isMatched=true when similarity exceeds threshold', async () => {
+    const { FaceDetector, FaceNet } = require('@/shared/native')
+    const { cosineSimilarity } = require('@/shared/lib')
+
+    FaceDetector.detect.mockResolvedValue([mockBox])
+    FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+    cosineSimilarity.mockReturnValue(0.9)
+
+    const result = await detectAndClassify('file://image.jpg', [makeStoredEmbedding('1', 'p1')])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].isMatched).toBe(true)
+    expect(result[0].isSelected).toBe(true)
+    expect(result[0].box).toEqual(mockBox)
+  })
+
+  it('returns candidate with isMatched=false when similarity does not exceed threshold', async () => {
+    const { FaceDetector, FaceNet } = require('@/shared/native')
+    const { cosineSimilarity } = require('@/shared/lib')
+
+    FaceDetector.detect.mockResolvedValue([mockBox])
+    FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+    cosineSimilarity.mockReturnValue(0.3)
+
+    const result = await detectAndClassify('file://image.jpg', [makeStoredEmbedding('1', 'p1')])
+
+    expect(result[0].isMatched).toBe(false)
+    expect(result[0].isSelected).toBe(false)
+  })
+
+  it('isMatched=false when similarity equals threshold exactly (strict >)', async () => {
+    const { FaceDetector, FaceNet } = require('@/shared/native')
+    const { cosineSimilarity } = require('@/shared/lib')
+
+    FaceDetector.detect.mockResolvedValue([mockBox])
+    FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+    cosineSimilarity.mockReturnValue(THRESHOLD)
+
+    const result = await detectAndClassify('file://image.jpg', [makeStoredEmbedding('1', 'p1')])
+
+    expect(result[0].isMatched).toBe(false)
+  })
+
+  it('throws when FaceNet returns fewer embeddings than detected faces', async () => {
+    const { FaceDetector, FaceNet } = require('@/shared/native')
+
+    FaceDetector.detect.mockResolvedValue([mockBox, { x: 100, y: 0, width: 50, height: 50 }])
+    FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+
+    await expect(
+      detectAndClassify('file://image.jpg', [makeStoredEmbedding('1', 'p1')])
+    ).rejects.toThrow('FaceNet embedding count mismatch')
+  })
+
+  it('skips corrupt embedding and continues matching', async () => {
+    const { FaceDetector, FaceNet } = require('@/shared/native')
+    const { cosineSimilarity } = require('@/shared/lib')
+
+    FaceDetector.detect.mockResolvedValue([mockBox])
+    FaceNet.extractAll.mockResolvedValue([mockEmbedding])
+    cosineSimilarity.mockReturnValue(0.9)
+
+    const corruptRecord = { id: 'bad', person_id: 'p1', embedding: 'INVALID_JSON', source_uri: 'u', created_at: NOW, updated_at: NOW }
+    const validRecord = makeStoredEmbedding('good', 'p2')
+
+    const result = await detectAndClassify('file://image.jpg', [corruptRecord, validRecord])
+
+    expect(result[0].isMatched).toBe(true)
+  })
+})

--- a/src/features/image-processing/model/__tests__/useFaceSelection.test.ts
+++ b/src/features/image-processing/model/__tests__/useFaceSelection.test.ts
@@ -1,0 +1,110 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native'
+import { useFaceSelection } from '../useFaceSelection'
+
+const mockBox = { x: 0, y: 0, width: 50, height: 50 }
+const mockCandidate = { box: mockBox, isMatched: true, isSelected: true }
+
+jest.mock('../detectAndClassify', () => ({ detectAndClassify: jest.fn() }))
+jest.mock('../applyMosaicToSelected', () => ({ applyMosaicToSelected: jest.fn() }))
+
+describe('useFaceSelection', () => {
+  beforeEach(() => { jest.clearAllMocks() })
+
+  it('starts in detecting phase', () => {
+    const { detectAndClassify } = require('../detectAndClassify')
+    detectAndClassify.mockReturnValue(new Promise(() => {}))
+
+    const { result } = renderHook(() => useFaceSelection('file://image.jpg'))
+
+    expect(result.current.phase).toBe('detecting')
+    expect(result.current.candidates).toEqual([])
+    expect(result.current.resultUri).toBeUndefined()
+  })
+
+  it('transitions to error when no faces detected', async () => {
+    const { detectAndClassify } = require('../detectAndClassify')
+    detectAndClassify.mockResolvedValue([])
+
+    const { result } = renderHook(() => useFaceSelection('file://image.jpg'))
+
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+    expect(result.current.error?.message).toBe('顔が検出されませんでした')
+  })
+
+  it('transitions to selecting when faces detected', async () => {
+    const { detectAndClassify } = require('../detectAndClassify')
+    detectAndClassify.mockResolvedValue([mockCandidate])
+
+    const { result } = renderHook(() => useFaceSelection('file://image.jpg'))
+
+    await waitFor(() => expect(result.current.phase).toBe('selecting'))
+    expect(result.current.candidates).toEqual([mockCandidate])
+  })
+
+  it('toggleFace inverts isSelected of the specified index', async () => {
+    const { detectAndClassify } = require('../detectAndClassify')
+    detectAndClassify.mockResolvedValue([mockCandidate])
+
+    const { result } = renderHook(() => useFaceSelection('file://image.jpg'))
+    await waitFor(() => expect(result.current.phase).toBe('selecting'))
+
+    act(() => { result.current.toggleFace(0) })
+
+    expect(result.current.candidates[0].isSelected).toBe(false)
+  })
+
+  it('toggleFace does not affect other candidates', async () => {
+    const { detectAndClassify } = require('../detectAndClassify')
+    const candidateA = { box: mockBox, isMatched: true, isSelected: true }
+    const candidateB = { box: { x: 100, y: 0, width: 50, height: 50 }, isMatched: false, isSelected: false }
+    detectAndClassify.mockResolvedValue([candidateA, candidateB])
+
+    const { result } = renderHook(() => useFaceSelection('file://image.jpg'))
+    await waitFor(() => expect(result.current.phase).toBe('selecting'))
+
+    act(() => { result.current.toggleFace(0) })
+
+    expect(result.current.candidates[0].isSelected).toBe(false)
+    expect(result.current.candidates[1].isSelected).toBe(false)
+  })
+
+  it('confirm transitions to processing then done', async () => {
+    const { detectAndClassify } = require('../detectAndClassify')
+    const { applyMosaicToSelected } = require('../applyMosaicToSelected')
+    detectAndClassify.mockResolvedValue([mockCandidate])
+    applyMosaicToSelected.mockResolvedValue('file://result.jpg')
+
+    const { result } = renderHook(() => useFaceSelection('file://image.jpg'))
+    await waitFor(() => expect(result.current.phase).toBe('selecting'))
+
+    act(() => { result.current.confirm() })
+
+    await waitFor(() => expect(result.current.phase).toBe('done'))
+    expect(result.current.resultUri).toBe('file://result.jpg')
+  })
+
+  it('transitions to error when detectAndClassify throws', async () => {
+    const { detectAndClassify } = require('../detectAndClassify')
+    detectAndClassify.mockRejectedValue(new Error('detector error'))
+
+    const { result } = renderHook(() => useFaceSelection('file://image.jpg'))
+
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+    expect(result.current.error?.message).toBe('detector error')
+  })
+
+  it('transitions to error when applyMosaicToSelected throws', async () => {
+    const { detectAndClassify } = require('../detectAndClassify')
+    const { applyMosaicToSelected } = require('../applyMosaicToSelected')
+    detectAndClassify.mockResolvedValue([mockCandidate])
+    applyMosaicToSelected.mockRejectedValue(new Error('mosaic error'))
+
+    const { result } = renderHook(() => useFaceSelection('file://image.jpg'))
+    await waitFor(() => expect(result.current.phase).toBe('selecting'))
+
+    act(() => { result.current.confirm() })
+
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+    expect(result.current.error?.message).toBe('mosaic error')
+  })
+})

--- a/src/features/image-processing/model/applyMosaicToSelected.ts
+++ b/src/features/image-processing/model/applyMosaicToSelected.ts
@@ -1,0 +1,20 @@
+import { Mosaic } from '@/shared/native'
+import { resizeForMosaic } from '@/shared/lib'
+import type { FaceCandidate } from './types'
+
+export async function applyMosaicToSelected(
+  uri: string,
+  candidates: FaceCandidate[]
+): Promise<string> {
+  const selected = candidates.filter((c) => c.isSelected)
+  if (selected.length === 0) return uri
+
+  const { uri: resizedUri, scale } = await resizeForMosaic(uri)
+  const scaledRegions = selected.map(({ box }) => ({
+    x: box.x * scale,
+    y: box.y * scale,
+    width: box.width * scale,
+    height: box.height * scale,
+  }))
+  return Mosaic.apply(resizedUri, scaledRegions)
+}

--- a/src/features/image-processing/model/detectAndClassify.ts
+++ b/src/features/image-processing/model/detectAndClassify.ts
@@ -1,0 +1,51 @@
+import { FaceDetector, FaceNet } from '@/shared/native'
+import { getAllEmbeddings } from '@/shared/db'
+import type { Embedding } from '@/shared/db'
+import { cosineSimilarity, cropFace } from '@/shared/lib'
+import { getThreshold } from '@/shared/config'
+import type { FaceCandidate } from './types'
+
+export async function detectAndClassify(
+  uri: string,
+  preloadedEmbeddings?: Embedding[]
+): Promise<FaceCandidate[]> {
+  const boxes = await FaceDetector.detect(uri)
+  if (boxes.length === 0) return []
+
+  const croppedUris = await Promise.all(boxes.map((box) => cropFace(uri, box)))
+  const faceEmbeddings = await FaceNet.extractAll(croppedUris)
+
+  if (faceEmbeddings.length !== boxes.length) {
+    throw new Error(
+      `[detectAndClassify] FaceNet embedding count mismatch: expected ${boxes.length}, got ${faceEmbeddings.length}`
+    )
+  }
+
+  const storedEmbeddings = preloadedEmbeddings ?? (await getAllEmbeddings())
+
+  const embeddingsByPerson = storedEmbeddings.reduce<Record<string, number[][]>>(
+    (acc, stored) => {
+      let vec: number[]
+      try {
+        vec = JSON.parse(stored.embedding)
+      } catch (e) {
+        console.error('[detectAndClassify] Corrupt embedding record skipped', {
+          embeddingId: stored.id,
+          personId: stored.person_id,
+          error: e,
+        })
+        return acc
+      }
+      ;(acc[stored.person_id] ??= []).push(vec)
+      return acc
+    },
+    {}
+  )
+
+  return boxes.map((box, i) => {
+    const isMatched = Object.values(embeddingsByPerson).some((vecs) =>
+      vecs.some((v) => cosineSimilarity(faceEmbeddings[i], v) > getThreshold())
+    )
+    return { box, isMatched, isSelected: isMatched }
+  })
+}

--- a/src/features/image-processing/model/processImage.ts
+++ b/src/features/image-processing/model/processImage.ts
@@ -1,59 +1,9 @@
-import { FaceDetector, FaceNet, Mosaic } from '@/shared/native'
-import { getAllEmbeddings } from '@/shared/db'
 import type { Embedding } from '@/shared/db'
-import { cosineSimilarity, cropFace, resizeForMosaic } from '@/shared/lib'
-import { getThreshold } from '@/shared/config'
+import { detectAndClassify } from './detectAndClassify'
+import { applyMosaicToSelected } from './applyMosaicToSelected'
 
 export async function processImage(uri: string, preloadedEmbeddings?: Embedding[]): Promise<string> {
-  const boxes = await FaceDetector.detect(uri)
-  if (boxes.length === 0) return uri
-
-  const croppedUris = await Promise.all(boxes.map((box) => cropFace(uri, box)))
-  const faceEmbeddings = await FaceNet.extractAll(croppedUris)
-
-  if (faceEmbeddings.length !== boxes.length) {
-    throw new Error(
-      `[processImage] FaceNet embedding count mismatch: expected ${boxes.length}, got ${faceEmbeddings.length}`
-    )
-  }
-
-  const storedEmbeddings = preloadedEmbeddings ?? (await getAllEmbeddings())
-
-  // person_id ごとにグループ化し、いずれか1件でも閾値を超えれば一致とみなす（CLAUDE.md 照合方針）
-  const embeddingsByPerson = storedEmbeddings.reduce<Record<string, number[][]>>(
-    (acc, stored) => {
-      let vec: number[]
-      try {
-        vec = JSON.parse(stored.embedding)
-      } catch (e) {
-        console.error('[processImage] Corrupt embedding record skipped', {
-          embeddingId: stored.id,
-          personId: stored.person_id,
-          error: e,
-        })
-        return acc
-      }
-      ;(acc[stored.person_id] ??= []).push(vec)
-      return acc
-    },
-    {}
-  )
-
-  const regionsToBlur = boxes.filter((_, i) =>
-    Object.values(embeddingsByPerson).some((vecs) =>
-      vecs.some((v) => cosineSimilarity(faceEmbeddings[i], v) > getThreshold())
-    )
-  )
-
-  if (regionsToBlur.length === 0) return uri
-
-  // Skia のデコード失敗を防ぐため ImageManipulator で正規化してから渡す
-  const { uri: resizedUri, scale } = await resizeForMosaic(uri)
-  const scaledRegions = regionsToBlur.map((box) => ({
-    x: box.x * scale,
-    y: box.y * scale,
-    width: box.width * scale,
-    height: box.height * scale,
-  }))
-  return Mosaic.apply(resizedUri, scaledRegions)
+  const candidates = await detectAndClassify(uri, preloadedEmbeddings)
+  if (candidates.length === 0) return uri
+  return applyMosaicToSelected(uri, candidates)
 }

--- a/src/features/image-processing/model/types.ts
+++ b/src/features/image-processing/model/types.ts
@@ -1,0 +1,7 @@
+import type { BoundingBox } from '@/shared/native'
+
+export interface FaceCandidate {
+  box: BoundingBox
+  isMatched: boolean
+  isSelected: boolean
+}

--- a/src/features/image-processing/model/useFaceSelection.ts
+++ b/src/features/image-processing/model/useFaceSelection.ts
@@ -1,0 +1,64 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { detectAndClassify } from './detectAndClassify'
+import { applyMosaicToSelected } from './applyMosaicToSelected'
+import type { FaceCandidate } from './types'
+
+type Phase = 'detecting' | 'selecting' | 'processing' | 'done' | 'error'
+
+interface FaceSelectionState {
+  phase: Phase
+  candidates: FaceCandidate[]
+  resultUri: string | undefined
+  error: Error | undefined
+  toggleFace: (index: number) => void
+  confirm: () => void
+}
+
+export function useFaceSelection(uri: string): FaceSelectionState {
+  const [phase, setPhase] = useState<Phase>('detecting')
+  const [candidates, setCandidates] = useState<FaceCandidate[]>([])
+  const [resultUri, setResultUri] = useState<string | undefined>(undefined)
+  const [error, setError] = useState<Error | undefined>(undefined)
+  const hasStarted = useRef(false)
+
+  useEffect(() => {
+    if (!uri || hasStarted.current) return
+    hasStarted.current = true
+
+    detectAndClassify(uri)
+      .then((result) => {
+        if (result.length === 0) {
+          setError(new Error('顔が検出されませんでした'))
+          setPhase('error')
+          return
+        }
+        setCandidates(result)
+        setPhase('selecting')
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err : new Error(String(err)))
+        setPhase('error')
+      })
+  }, [uri])
+
+  const toggleFace = useCallback((index: number) => {
+    setCandidates((prev) =>
+      prev.map((c, i) => (i === index ? { ...c, isSelected: !c.isSelected } : c))
+    )
+  }, [])
+
+  const confirm = useCallback(() => {
+    setPhase('processing')
+    applyMosaicToSelected(uri, candidates)
+      .then((result) => {
+        setResultUri(result)
+        setPhase('done')
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err : new Error(String(err)))
+        setPhase('error')
+      })
+  }, [uri, candidates])
+
+  return { phase, candidates, resultUri, error, toggleFace, confirm }
+}

--- a/src/features/image-processing/ui/FaceSelectionView.tsx
+++ b/src/features/image-processing/ui/FaceSelectionView.tsx
@@ -1,0 +1,128 @@
+import React, { useState, useEffect, useMemo } from 'react'
+import { View, Image, Text, StyleSheet, TouchableOpacity } from 'react-native'
+import type { LayoutChangeEvent } from 'react-native'
+import { FaceBox } from '@/shared/ui'
+import type { FaceCandidate } from '../model/types'
+
+interface FaceSelectionViewProps {
+  uri: string
+  candidates: FaceCandidate[]
+  onToggle: (index: number) => void
+  onConfirm: () => void
+}
+
+interface DisplayLayout {
+  scale: number
+  offsetX: number
+  offsetY: number
+}
+
+export function FaceSelectionView({ uri, candidates, onToggle, onConfirm }: FaceSelectionViewProps) {
+  const [naturalSize, setNaturalSize] = useState<{ width: number; height: number } | null>(null)
+  const [containerSize, setContainerSize] = useState<{ width: number; height: number } | null>(null)
+
+  useEffect(() => {
+    Image.getSize(uri, (w, h) => setNaturalSize({ width: w, height: h }))
+  }, [uri])
+
+  const layout = useMemo<DisplayLayout | null>(() => {
+    if (!naturalSize || !containerSize) return null
+    const scale = Math.min(
+      containerSize.width / naturalSize.width,
+      containerSize.height / naturalSize.height
+    )
+    return {
+      scale,
+      offsetX: (containerSize.width - naturalSize.width * scale) / 2,
+      offsetY: (containerSize.height - naturalSize.height * scale) / 2,
+    }
+  }, [naturalSize, containerSize])
+
+  const handleContainerLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout
+    setContainerSize({ width, height })
+  }
+
+  const selectedCount = candidates.filter((c) => c.isSelected).length
+
+  const { selectedBoxes, unselectedBoxes } = useMemo(() => {
+    if (!layout) return { selectedBoxes: [], unselectedBoxes: [] }
+    const { scale, offsetX, offsetY } = layout
+    const transform = (c: FaceCandidate) => ({
+      x: c.box.x * scale + offsetX,
+      y: c.box.y * scale + offsetY,
+      width: c.box.width * scale,
+      height: c.box.height * scale,
+    })
+    return {
+      selectedBoxes: candidates.filter((c) => c.isSelected).map(transform),
+      unselectedBoxes: candidates.filter((c) => !c.isSelected).map(transform),
+    }
+  }, [candidates, layout])
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.imageWrapper} onLayout={handleContainerLayout}>
+        <Image source={{ uri }} style={styles.image} resizeMode="contain" />
+        {layout && containerSize && (
+          <>
+            <FaceBox
+              width={containerSize.width}
+              height={containerSize.height}
+              boxes={selectedBoxes}
+              color="#FF3B30"
+              strokeWidth={3}
+            />
+            <FaceBox
+              width={containerSize.width}
+              height={containerSize.height}
+              boxes={unselectedBoxes}
+              color="#8E8E93"
+              strokeWidth={2}
+            />
+            {candidates.map((c, i) => (
+              <TouchableOpacity
+                key={i}
+                style={[
+                  styles.faceOverlay,
+                  {
+                    left: c.box.x * layout.scale + layout.offsetX,
+                    top: c.box.y * layout.scale + layout.offsetY,
+                    width: c.box.width * layout.scale,
+                    height: c.box.height * layout.scale,
+                  },
+                ]}
+                onPress={() => onToggle(i)}
+                activeOpacity={0.7}
+              />
+            ))}
+          </>
+        )}
+      </View>
+      <View style={styles.footer}>
+        <Text style={styles.countText}>
+          {candidates.length} 件中 {selectedCount} 件を隠します
+        </Text>
+        <TouchableOpacity style={styles.confirmButton} onPress={onConfirm}>
+          <Text style={styles.confirmText}>処理する</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  imageWrapper: { flex: 1, backgroundColor: '#000' },
+  image: { flex: 1, width: '100%' },
+  faceOverlay: { position: 'absolute' },
+  footer: { padding: 20, gap: 12 },
+  countText: { fontSize: 14, color: '#666', textAlign: 'center' },
+  confirmButton: {
+    backgroundColor: '#007AFF',
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  confirmText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+})


### PR DESCRIPTION
## Summary

- `processImage.ts` を「顔検出・照合（`detectAndClassify`）」と「モザイク適用（`applyMosaicToSelected`）」に分割し、バッチ処理との後方互換を維持
- 新 hook `useFaceSelection` で「detecting → selecting → processing → done / error」のフェーズ管理を実装
- 新コンポーネント `FaceSelectionView` で元画像上にバウンディングボックスをオーバーレイし、タップで隠す/隠さないを選択できる UI を追加

## Changes

- `src/features/image-processing/model/types.ts` — `FaceCandidate` 型（box / isMatched / isSelected）
- `src/features/image-processing/model/detectAndClassify.ts` — 顔検出・照合フェーズ（テスト6件）
- `src/features/image-processing/model/applyMosaicToSelected.ts` — 選択済み顔へのモザイク適用（テスト5件）
- `src/features/image-processing/model/useFaceSelection.ts` — 選択 UI hook（テスト8件）
- `src/features/image-processing/ui/FaceSelectionView.tsx` — 顔選択 UI コンポーネント
- `src/features/image-processing/model/processImage.ts` — 上記2関数で再実装（シグネチャ変更なし）
- `app/process/[imageId].tsx` — フェーズ別表示に更新

## Test Plan

- [ ] 全テスト（91件）が PASS することを確認: `bun run test --forceExit`
- [ ] 型チェックが通ることを確認: `bun run tsc`
- [ ] iOS シミュレーターで画像を選択し、顔検出後に選択 UI が表示されることを確認
- [ ] バウンディングボックスをタップして選択状態が切り替わることを確認
- [ ] 「処理する」ボタンで選択した顔のみモザイクが適用されることを確認
- [ ] 顔が検出されない画像で「顔が検出されませんでした」エラーが表示されることを確認

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)